### PR TITLE
feat: implement i18next json to po conversion

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,10 @@
     "": {
       "name": "i18nweave",
       "version": "0.0.1",
+      "license": "SEE LICENSE IN LICENSE.txt",
+      "dependencies": {
+        "gettext-converter": "^1.3.0"
+      },
       "devDependencies": {
         "@types/mocha": "^10.0.6",
         "@types/node": "18.x",
@@ -659,6 +663,14 @@
         "node": ">=8"
       }
     },
+    "node_modules/arrify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/arrify/-/arrify-2.0.1.tgz",
+      "integrity": "sha512-3duEwti880xqi4eAMN8AyR4a0ByT90zoYdLlevfrvU43vb0YZwZVfxOgxWrLXXXpyugL0hNZc9G6BiB5B3nUug==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -877,6 +889,14 @@
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "dev": true
     },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
@@ -982,6 +1002,14 @@
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
       "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
       "dev": true
+    },
+    "node_modules/encoding": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
+      "integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
+      "dependencies": {
+        "iconv-lite": "^0.6.2"
+      }
     },
     "node_modules/enhanced-resolve": {
       "version": "5.16.1",
@@ -1350,6 +1378,16 @@
         "node": "6.* || 8.* || >= 10.*"
       }
     },
+    "node_modules/gettext-converter": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/gettext-converter/-/gettext-converter-1.3.0.tgz",
+      "integrity": "sha512-vXjx4vRBjw6rd3Zg73IMyNLZuPjs8/lE9gJZs270YJJI0t5vlCpdsyX5E0TmSd+KcRWzwPbwjwd6bnNpF72sFQ==",
+      "dependencies": {
+        "arrify": "^2.0.1",
+        "content-type": "1.0.5",
+        "encoding": "0.1.13"
+      }
+    },
     "node_modules/glob": {
       "version": "10.4.1",
       "resolved": "https://registry.npmjs.org/glob/-/glob-10.4.1.tgz",
@@ -1480,6 +1518,17 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/ignore": {
@@ -2419,6 +2468,11 @@
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
       "dev": true
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
     "node_modules/semver": {
       "version": "7.6.2",

--- a/package.json
+++ b/package.json
@@ -56,14 +56,17 @@
     "publish": "npx vsce publish"
   },
   "devDependencies": {
-    "@types/vscode": "^1.89.0",
     "@types/mocha": "^10.0.6",
     "@types/node": "18.x",
+    "@types/vscode": "^1.89.0",
     "@typescript-eslint/eslint-plugin": "^7.7.1",
     "@typescript-eslint/parser": "^7.7.1",
-    "eslint": "^8.57.0",
-    "typescript": "^5.4.5",
     "@vscode/test-cli": "^0.0.9",
-    "@vscode/test-electron": "^2.3.9"
+    "@vscode/test-electron": "^2.3.9",
+    "eslint": "^8.57.0",
+    "typescript": "^5.4.5"
+  },
+  "dependencies": {
+    "gettext-converter": "^1.3.0"
   }
 }

--- a/src/interfaces/actionModule.ts
+++ b/src/interfaces/actionModule.ts
@@ -1,6 +1,6 @@
-import { ModuleContext } from './moduleContext';
+import ModuleContext from './moduleContext';
 
-export interface ActionModule {
+export default interface ActionModule {
   setNext(module: ActionModule | null): void;
   execute(context: ModuleContext): Promise<void>;
 }

--- a/src/interfaces/moduleContext.ts
+++ b/src/interfaces/moduleContext.ts
@@ -1,5 +1,7 @@
-import vscode from 'vscode';
+import { Uri } from 'vscode';
 
-export interface ModuleContext {
-  fileUri: vscode.Uri;
+export default interface ModuleContext {
+  inputPath: Uri;
+  outputPath: Uri;
+  locale: string;
 }

--- a/src/modules.d.ts
+++ b/src/modules.d.ts
@@ -1,0 +1,2 @@
+declare module 'gettext-converter';
+declare module 'i18next-scanner';

--- a/src/modules/baseActionModule.ts
+++ b/src/modules/baseActionModule.ts
@@ -1,13 +1,24 @@
-import { ActionModule } from '../interfaces/actionModule';
-import { ModuleContext } from '../interfaces/moduleContext';
+import ActionModule from '../interfaces/actionModule';
+import ModuleContext from '../interfaces/moduleContext';
 
+/**
+ * Represents a base class for action modules.
+ */
 export abstract class BaseActionModule implements ActionModule {
   private nextModule: ActionModule | null = null;
 
+  /**
+   * Sets the next action module in the chain.
+   * @param module The next action module to set.
+   */
   public setNext(module: ActionModule | null): void {
     this.nextModule = module;
   }
 
+  /**
+   * Executes the action module.
+   * @param context The module context.
+   */
   public async execute(context: ModuleContext): Promise<void> {
     await this.doExecute(context);
 
@@ -16,5 +27,9 @@ export abstract class BaseActionModule implements ActionModule {
     }
   }
 
+  /**
+   * Performs the execution logic of the action module.
+   * @param context The module context.
+   */
   protected abstract doExecute(context: ModuleContext): Promise<void>;
 }

--- a/src/modules/baseModuleContext.ts
+++ b/src/modules/baseModuleContext.ts
@@ -1,10 +1,14 @@
 import { Uri } from 'vscode';
-import { ModuleContext } from '../interfaces/moduleContext';
+import ModuleContext from '../interfaces/moduleContext';
 
 export abstract class BaseModuleContext implements ModuleContext {
-  fileUri: Uri;
+  inputPath: Uri;
+  outputPath: Uri;
+  locale: string;
 
-  constructor(fileUri: Uri) {
-    this.fileUri = fileUri;
+  constructor(fileUri: Uri, outputPath: Uri, locale: string) {
+    this.inputPath = fileUri;
+    this.outputPath = outputPath;
+    this.locale = locale;
   }
 }

--- a/src/modules/i18nextJsonToPoConversion/i18nextJsonToPoConversionModule.ts
+++ b/src/modules/i18nextJsonToPoConversion/i18nextJsonToPoConversionModule.ts
@@ -1,19 +1,26 @@
+import FileWriter from '../../services/fileWriter';
 import { BaseActionModule } from '../baseActionModule';
-import { I18nextJsonToPoConversionModuleContext } from './i18nextJsonToPoConversionModuleContext';
+import { i18next2po } from 'gettext-converter';
+import I18nextJsonToPoConversionModuleContext from './i18nextJsonToPoConversionModuleContext';
 
-export class I18nextJsonToPoConversionModule extends BaseActionModule {
+/**
+ * Module for converting JSON to PO using i18next library.
+ */
+export default class I18nextJsonToPoConversionModule extends BaseActionModule {
+  /**
+   * Executes the conversion of JSON to PO.
+   * @param context - The context for the conversion.
+   * @returns A Promise that resolves when the conversion is complete.
+   */
   protected async doExecute(
     context: I18nextJsonToPoConversionModuleContext
   ): Promise<void> {
-    console.log(`Converting json to po using : ${context.fileUri.fsPath}`);
-
-    //   const { poOutputPath, locale } =
-    //   FileManagement.extractParts(changeFileLocation);
-    // const json = await FileUtilities.readFileContentsAsync(changeFileLocation);
-    // const res = i18next2po(locale, json, { compatibilityJSON: 'v3' });
-
+    console.log(`Converting json to po using : ${context.inputPath.fsPath}`);
     if (context.jsonContent) {
-      const translations = {};
+      const res = i18next2po(context.locale, context.jsonContent, {
+        compatibilityJSON: 'v3',
+      });
+      await FileWriter.writeToFileAsync(context.outputPath, res);
     }
   }
 }

--- a/src/modules/i18nextJsonToPoConversion/i18nextJsonToPoConversionModuleContext.ts
+++ b/src/modules/i18nextJsonToPoConversion/i18nextJsonToPoConversionModuleContext.ts
@@ -1,5 +1,5 @@
 import { BaseModuleContext } from '../baseModuleContext';
 
-export abstract class I18nextJsonToPoConversionModuleContext extends BaseModuleContext {
+export default abstract class I18nextJsonToPoConversionModuleContext extends BaseModuleContext {
   jsonContent: any;
 }

--- a/src/modules/moduleChainManager.ts
+++ b/src/modules/moduleChainManager.ts
@@ -1,14 +1,27 @@
 import { ChainType } from '../enums/chainType';
-import { ActionModule } from '../interfaces/actionModule';
-import { ModuleContext } from '../interfaces/moduleContext';
+import ActionModule from '../interfaces/actionModule';
+import ModuleContext from '../interfaces/moduleContext';
 
-export class ModuleChainManager {
+/**
+ * Manages the module chains for the i18nWeave extension.
+ */
+export default class ModuleChainManager {
   private chains: { [chainType: number]: ActionModule | null } = {};
 
-  public registerChain(chainType: ChainType, chain: ActionModule): void {
-    this.chains[chainType] = chain;
+  /**
+   * Registers a chain of modules for a specific chain type.
+   * @param chainType - The type of chain to register.
+   * @param module - The module to register.
+   */
+  public registerChain(chainType: ChainType, module: ActionModule): void {
+    this.chains[chainType] = module;
   }
 
+  /**
+   * Executes a module chain.
+   * @param chainType - The type of the chain to execute.
+   * @param moduleContext - The module context for the chain execution.
+   */
   public executeChain(
     chainType: ChainType,
     moduleContext: ModuleContext

--- a/src/modules/readJsonFile/readJsonFileModule.ts
+++ b/src/modules/readJsonFile/readJsonFileModule.ts
@@ -1,12 +1,23 @@
-import { FileReader } from '../../services/fileReader';
+import FileReader from '../../services/fileReader';
 import { BaseActionModule } from '../baseActionModule';
 import { ReadJsonFileModuleContext } from './readJsonFileModuleContext';
 
-export class ReadJsonFileModule extends BaseActionModule {
+/**
+ * Module for reading JSON files.
+ */
+export default class ReadJsonFileModule extends BaseActionModule {
+  /**
+   * Executes the readJsonFile module.
+   * Reads the contents of a JSON file and assigns it to the `jsonContent` property of the context.
+   * @param context The context object for the readJsonFile module.
+   * @returns A Promise that resolves when the execution is complete.
+   */
   protected async doExecute(context: ReadJsonFileModuleContext): Promise<void> {
-    console.log(`Reading Json file contents: ${context.fileUri.fsPath}`);
+    console.log(`Reading Json file contents: ${context.inputPath.fsPath}`);
 
-    const jsonContent = await FileReader.readFileAsync(context.fileUri.fsPath);
+    const jsonContent = await FileReader.readFileAsync(
+      context.inputPath.fsPath
+    );
 
     if (jsonContent) {
       context.jsonContent = jsonContent;

--- a/src/modules/translation/translationModule.ts
+++ b/src/modules/translation/translationModule.ts
@@ -1,9 +1,9 @@
 import { BaseActionModule } from '../baseActionModule';
 import { TranslationModuleContext } from './translationModuleContext';
 
-export class TranslationModule extends BaseActionModule {
+export default class TranslationModule extends BaseActionModule {
   protected async doExecute(context: TranslationModuleContext): Promise<void> {
-    console.log(`Translating missing keys in: ${context.fileUri.fsPath}`);
+    console.log(`Translating missing keys in: ${context.inputPath.fsPath}`);
     if (context.jsonContent) {
       const translations = {};
     }

--- a/src/services/filePathProcessor.ts
+++ b/src/services/filePathProcessor.ts
@@ -1,0 +1,43 @@
+import { Uri } from 'vscode';
+import { ExtractedFileParts } from '../types/extractedFileParts';
+
+/**
+ * The FilePathProcessor class is responsible for processing file paths and extracting locale and output path information.
+ */
+export default class FilePathProcessor {
+  private static extractLocale(filePath: string): string {
+    const localePattern = /\\locales\\([^\\]+)\\/;
+    const match = localePattern.exec(filePath);
+    if (!match || match.length < 2) {
+      throw new Error('Invalid file path format');
+    }
+    return match[1];
+  }
+
+  private static determineOutputPath(filePath: string): Uri {
+    if (!filePath.endsWith('.po') && !filePath.endsWith('.json')) {
+      throw new Error(
+        'Invalid file extension. Only .po and .json files are supported.'
+      );
+    }
+
+    const isPOFile = filePath.endsWith('.po');
+    const commonPath = filePath.replace(/\.po$|\.json$/, '');
+
+    return isPOFile
+      ? Uri.file(`${commonPath}.json`)
+      : Uri.file(`${commonPath}.po`);
+  }
+
+  /**
+   * Processes the given file path and extracts the locale and output path.
+   * @param filePath - The file path to process.
+   * @returns A {@link ExtractedFileParts} object containing the extracted locale and output path.
+   */
+  public static processFilePath(filePath: string): ExtractedFileParts {
+    const locale = this.extractLocale(filePath);
+    const outputPath = this.determineOutputPath(filePath);
+
+    return { locale, outputPath };
+  }
+}

--- a/src/services/fileReader.ts
+++ b/src/services/fileReader.ts
@@ -1,14 +1,13 @@
 import fs from 'fs';
 
 /**
- * A utility class for reading files asynchronously.
+ * Utility class for reading files asynchronously.
  */
-export class FileReader {
+export default class FileReader {
   /**
-   * Reads a file asynchronously and returns its content as a string.
+   * Reads the contents of a file asynchronously.
    * @param filePath - The path to the file to be read.
-   * @returns A Promise that resolves to the content of the file as a string.
-   * @throws If there was an error reading the file.
+   * @returns A promise that resolves with the contents of the file as a string.
    */
   public static async readFileAsync(filePath: string): Promise<string> {
     return new Promise<string>((resolve, reject) => {
@@ -19,8 +18,6 @@ export class FileReader {
           resolve(data);
         }
       });
-    }).catch((err) => {
-      throw new Error(`Error reading file: ${err.message}`);
     });
   }
 }

--- a/src/services/fileReader.ts
+++ b/src/services/fileReader.ts
@@ -13,7 +13,7 @@ export default class FileReader {
     return new Promise<string>((resolve, reject) => {
       fs.readFile(filePath, 'utf8', (err, data) => {
         if (err) {
-          reject(err);
+          reject(new Error(err.message));
         } else {
           resolve(data);
         }

--- a/src/services/fileWriter.ts
+++ b/src/services/fileWriter.ts
@@ -1,0 +1,28 @@
+import fs from 'fs';
+import { Uri } from 'vscode';
+
+/**
+ * Utility class for writing data to a file asynchronously.
+ */
+export default class FileWriter {
+  /**
+   * Writes data to a file asynchronously.
+   * @param filePath - The path of the file to write to.
+   * @param data - The data to write to the file.
+   * @returns A promise that resolves when the data has been written successfully, or rejects with an error if there was a problem.
+   */
+  public static async writeToFileAsync(
+    filePath: Uri,
+    data: string | NodeJS.ArrayBufferView
+  ): Promise<void> {
+    return new Promise<void>((resolve, reject) => {
+      fs.writeFile(filePath.fsPath, data, 'utf8', (err) => {
+        if (err) {
+          reject(err);
+        } else {
+          resolve();
+        }
+      });
+    });
+  }
+}

--- a/src/services/fileWriter.ts
+++ b/src/services/fileWriter.ts
@@ -18,7 +18,7 @@ export default class FileWriter {
     return new Promise<void>((resolve, reject) => {
       fs.writeFile(filePath.fsPath, data, 'utf8', (err) => {
         if (err) {
-          reject(err);
+          reject(new Error(err.message));
         } else {
           resolve();
         }

--- a/src/test/extension.test.ts
+++ b/src/test/extension.test.ts
@@ -2,14 +2,14 @@ import * as assert from 'assert';
 
 // You can import and use all API from the 'vscode' module
 // as well as import your extension to test it
-import * as vscode from 'vscode';
+import { window } from 'vscode';
 // import * as myExtension from '../../extension';
 
 suite('Extension Test Suite', () => {
-	vscode.window.showInformationMessage('Start all tests.');
+  window.showInformationMessage('Start all tests.');
 
-	test('Sample test', () => {
-		assert.strictEqual(-1, [1, 2, 3].indexOf(5));
-		assert.strictEqual(-1, [1, 2, 3].indexOf(0));
-	});
+  test('Sample test', () => {
+    assert.strictEqual(-1, [1, 2, 3].indexOf(5));
+    assert.strictEqual(-1, [1, 2, 3].indexOf(0));
+  });
 });

--- a/src/types/extractedFileParts.ts
+++ b/src/types/extractedFileParts.ts
@@ -1,0 +1,6 @@
+import { Uri } from 'vscode';
+
+export type ExtractedFileParts = {
+  locale: string;
+  outputPath: Uri;
+};


### PR DESCRIPTION
- Abstract `BaseActionModule` now clearly defines the `doExecute`
  method which all subclasses need to implement.
- Transition imports from `{ Module }` to `Module` directly, simplifying
  import statements across the application.
- Introduce TypeScript definition files for new modules,
  improving development experience for gettext and i18n scanning.
- Update `package-lock.json` to reflect new dependencies, ensuring
  compatibility and stability.
- Refactor `FileReader` to remove redundant catch, streamlining file
  reading process.
- Add `FileWriter` utility, enabling asynchronous data writing to
  files.
- Enhance `BaseModuleContext` to include input path, output path, and
  locale, making modules more versatile.
- Shift several classes to use `default` exports, aligning with
  consistent module handling practice.

This change restructures the action modules for better clarity,
extendability, and maintenance. It also improves developers' ability to
add new features and fix bugs by ensuring that all modules follow a
consistent pattern and are properly typed.