### PR TITLE
feat: add file manipulation & testing utilities

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
       },
       "devDependencies": {
         "@types/mocha": "^10.0.6",
+        "@types/mock-fs": "^4.13.4",
         "@types/node": "18.x",
         "@types/vscode": "^1.89.0",
         "@typescript-eslint/eslint-plugin": "^7.7.1",
@@ -20,6 +21,7 @@
         "@vscode/test-cli": "^0.0.9",
         "@vscode/test-electron": "^2.3.9",
         "eslint": "^8.57.0",
+        "mock-fs": "^5.2.0",
         "typescript": "^5.4.5"
       },
       "engines": {
@@ -308,6 +310,15 @@
       "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-10.0.6.tgz",
       "integrity": "sha512-dJvrYWxP/UcXm36Qn36fxhUKu8A/xMRXVT2cliFF1Z7UA9liG5Psj3ezNSZw+5puH2czDXRLcXQxf8JbJt0ejg==",
       "dev": true
+    },
+    "node_modules/@types/mock-fs": {
+      "version": "4.13.4",
+      "resolved": "https://registry.npmjs.org/@types/mock-fs/-/mock-fs-4.13.4.tgz",
+      "integrity": "sha512-mXmM0o6lULPI8z3XNnQCpL0BGxPwx1Ul1wXYEPBGl4efShyxW2Rln0JOPEWGyZaYZMM6OVXM/15zUuFMY52ljg==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@types/node": {
       "version": "18.19.33",
@@ -2114,6 +2125,15 @@
       "dev": true,
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/mock-fs": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/mock-fs/-/mock-fs-5.2.0.tgz",
+      "integrity": "sha512-2dF2R6YMSZbpip1V1WHKGLNjr/k48uQClqMVb5H3MOvwc9qhYis3/IWbj02qIg/Y8MDXKFF4c5v0rxx2o6xTZw==",
+      "dev": true,
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/ms": {

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
   },
   "devDependencies": {
     "@types/mocha": "^10.0.6",
+    "@types/mock-fs": "^4.13.4",
     "@types/node": "18.x",
     "@types/vscode": "^1.89.0",
     "@typescript-eslint/eslint-plugin": "^7.7.1",
@@ -58,6 +59,7 @@
     "@vscode/test-cli": "^0.0.9",
     "@vscode/test-electron": "^2.3.9",
     "eslint": "^8.57.0",
+    "mock-fs": "^5.2.0",
     "typescript": "^5.4.5"
   },
   "dependencies": {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,4 +1,4 @@
-import { ExtensionContext, commands, window } from 'vscode';
+import { ExtensionContext } from 'vscode';
 import FileWatcherCreator from './services/fileWatcherCreator';
 
 export async function activate(context: ExtensionContext) {

--- a/src/test/services/fileChangeHandlerFactory.test.ts
+++ b/src/test/services/fileChangeHandlerFactory.test.ts
@@ -1,0 +1,23 @@
+import * as assert from 'assert';
+import FileChangeHandlerFactory from '../../services/fileChangeHandlerFactory';
+import JsonFileChangeHandler from '../../fileChangeHandlers/jsonFileChangeHandler';
+
+suite('FileChangeHandlerFactory Tests', () => {
+  test('createFileChangeHandler should return an instance of JsonFileChangeHandler for json file', () => {
+    const factory = new FileChangeHandlerFactory();
+    const changeFileLocation = '/path/to/file.json';
+
+    const handler = factory.createFileChangeHandler(changeFileLocation);
+
+    assert.strictEqual(handler instanceof JsonFileChangeHandler, true);
+  });
+
+  test('createFileChangeHandler should return undefined for unsupported file extension', () => {
+    const factory = new FileChangeHandlerFactory();
+    const changeFileLocation = '/path/to/file.txt';
+
+    const handler = factory.createFileChangeHandler(changeFileLocation);
+
+    assert.strictEqual(handler, undefined);
+  });
+});

--- a/src/test/services/filePathProcessor.test.ts
+++ b/src/test/services/filePathProcessor.test.ts
@@ -1,0 +1,43 @@
+import * as assert from 'assert';
+import { Uri } from 'vscode';
+import FilePathProcessor from '../../services/filePathProcessor';
+
+suite('FilePathProcessor Tests', () => {
+  test('processFilePath should extract locale and output path for .po file', () => {
+    const filePath = 'C:\\path\\to\\locales\\en\\file.po';
+    const expectedLocale = 'en';
+    const expectedOutputPath = Uri.file('C:\\path\\to\\locales\\en\\file.json');
+
+    const result = FilePathProcessor.processFilePath(filePath);
+
+    assert.strictEqual(result.locale, expectedLocale);
+    assert.deepStrictEqual(result.outputPath, expectedOutputPath);
+  });
+
+  test('processFilePath should extract locale and output path for .json file', () => {
+    const filePath = 'C:\\path\\to\\locales\\fr\\file.json';
+    const expectedLocale = 'fr';
+    const expectedOutputPath = Uri.file('C:\\path\\to\\locales\\fr\\file.po');
+
+    const result = FilePathProcessor.processFilePath(filePath);
+
+    assert.strictEqual(result.locale, expectedLocale);
+    assert.deepStrictEqual(result.outputPath, expectedOutputPath);
+  });
+
+  test('processFilePath should throw an error for invalid file path format', () => {
+    const filePath = 'C:\\path\\to\\invalid\\file.txt';
+
+    assert.throws(() => {
+      FilePathProcessor.processFilePath(filePath);
+    }, Error);
+  });
+
+  test('processFilePath should throw an error for unsupported file extension', () => {
+    const filePath = 'C:\\path\\to\\locales\\es\\file.txt';
+
+    assert.throws(() => {
+      FilePathProcessor.processFilePath(filePath);
+    }, Error);
+  });
+});

--- a/src/test/services/fileReader.test.ts
+++ b/src/test/services/fileReader.test.ts
@@ -1,0 +1,36 @@
+import * as assert from 'assert';
+import { Uri } from 'vscode';
+import FileReader from '../../services/fileReader';
+import * as mock from 'mock-fs';
+
+suite('FileReader Tests', () => {
+  setup(() => {
+    mock.default({
+      '/path/to/file.txt': 'Hello, World!',
+    });
+  });
+
+  teardown(() => {
+    mock.restore();
+  });
+
+  test('readFileAsync should read the contents of a file', async () => {
+    const filePath = Uri.file('/path/to/file.txt');
+    const expectedData = 'Hello, World!';
+
+    const fileContent = await FileReader.readFileAsync(filePath.fsPath);
+
+    assert.strictEqual(fileContent, expectedData);
+  });
+
+  test('readFileAsync should reject with an error if there is a problem', async () => {
+    const filePath = Uri.file('/path/to/nonexistent/file.txt');
+
+    try {
+      await FileReader.readFileAsync(filePath.fsPath);
+      assert.fail('Expected an error to be thrown');
+    } catch (error) {
+      assert.strictEqual(error instanceof Error, true);
+    }
+  });
+});

--- a/src/test/services/fileWriter.test.ts
+++ b/src/test/services/fileWriter.test.ts
@@ -1,0 +1,39 @@
+import * as assert from 'assert';
+import * as fs from 'fs';
+import { Uri } from 'vscode';
+import FileWriter from '../../services/fileWriter';
+import * as mock from 'mock-fs';
+
+suite('FileWriter Tests', () => {
+  setup(() => {
+    mock.default({
+      '/path/to/file.txt': 'Hello, World!',
+    });
+  });
+
+  teardown(() => {
+    mock.restore();
+  });
+
+  test('writeToFileAsync should write data to a file', async () => {
+    const filePath = Uri.file('/path/to/file.txt');
+    const data = 'Hello, World!';
+
+    await FileWriter.writeToFileAsync(filePath, data);
+
+    const fileContent = fs.readFileSync(filePath.fsPath, 'utf8');
+    assert.strictEqual(fileContent, data);
+  });
+
+  test('writeToFileAsync should reject with an error if there is a problem', async () => {
+    const filePath = Uri.file('/path/to/nonexistent/file.txt');
+    const data = 'Hello, World!';
+
+    try {
+      await FileWriter.writeToFileAsync(filePath, data);
+      assert.fail('Expected an error to be thrown');
+    } catch (error) {
+      assert.strictEqual(error instanceof Error, true);
+    }
+  });
+});


### PR DESCRIPTION
Implement new testing suites for file operations, including
reading, writing, and handling changes in file types, specifically
targeting `.json` and `.po` file conversions. Introduce `mock-fs`
for simulating file system in tests, enhancing test reliability
and isolation.