### PR TITLE
ci: integrate Codecov for coverage reports

### DIFF
--- a/.github/workflows/pullrequest.yml
+++ b/.github/workflows/pullrequest.yml
@@ -57,4 +57,9 @@ jobs:
       - name: Test
         #skip ubuntu-latest because of $DISPLAY
         if: ${{ matrix.os == 'macos-latest' || matrix.os == 'windows-latest' }}
-        run: npm run test
+        run: npm run test -- --coverage
+
+      - name: Upload coverage reports to Codecov
+        uses: codecov/codecov-action@v4.0.1
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/pullrequest.yml
+++ b/.github/workflows/pullrequest.yml
@@ -57,7 +57,7 @@ jobs:
       - name: Test
         #skip ubuntu-latest because of $DISPLAY
         if: ${{ matrix.os == 'macos-latest' || matrix.os == 'windows-latest' }}
-        run: npm run test -- --coverage
+        run: npm run test -- --coverage --coverage-reporter=clover
 
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v4.0.1


### PR DESCRIPTION
Add --coverage flag to npm test command to generate coverage
reports during the test phase in CI for macOS and Windows builds.
Upload generated coverage reports to Codecov using codecov-action
to track and ensure code quality across contributions. This
integration aims at maintaining and improving code coverage by
providing detailed insights into uncovered code paths.