### PR TITLE
ci(workflows): Trigger on PR and main push

### DIFF
--- a/.github/workflows/pullrequest.yml
+++ b/.github/workflows/pullrequest.yml
@@ -1,6 +1,10 @@
 name: Pull Request
 
-on: [pull_request]
+on:
+  pull_request:
+  push:
+    branches:
+      - main
 
 permissions:
   contents: write


### PR DESCRIPTION
Adjust the GitHub Actions workflow to trigger not only on pull
requests but also on push events to the main branch. This change
ensures that actions are executed for direct pushes to main, improving
CI/CD pipeline responsiveness and coverage.