### PR TITLE
refactor: improve file lock handling tests

### DIFF
--- a/src/fileChangeHandlers/jsonFileChangeHandler.ts
+++ b/src/fileChangeHandlers/jsonFileChangeHandler.ts
@@ -64,6 +64,7 @@ export default class JsonFileChangeHandler implements FileChangeHandler {
 
   /**
    * Handles the asynchronous file change event.
+   *
    * @param changeFileLocation - The location of the changed file.
    * @returns A promise that resolves when the file change is handled.
    */
@@ -86,14 +87,13 @@ export default class JsonFileChangeHandler implements FileChangeHandler {
 
     FileLockStoreStore.getInstance().add(extractedFileParts.outputPath);
 
-    JsonFileChangeHandler.moduleChainManager
-      .executeChain(ChainType.Json, context)
-      .finally(() => {
-        setTimeout(() => {
-          FileLockStoreStore.getInstance().delete(
-            extractedFileParts.outputPath
-          );
-        }, 250);
-      });
+    JsonFileChangeHandler.moduleChainManager.executeChain(
+      ChainType.Json,
+      context
+    );
+
+    setTimeout(() => {
+      FileLockStoreStore.getInstance().delete(extractedFileParts.outputPath);
+    }, 250);
   }
 }

--- a/src/fileChangeHandlers/poFileChangeHandler.ts
+++ b/src/fileChangeHandlers/poFileChangeHandler.ts
@@ -76,14 +76,10 @@ export default class PoFileChangeHandler implements FileChangeHandler {
 
     FileLockStoreStore.getInstance().add(extractedFileParts.outputPath);
 
-    PoFileChangeHandler.moduleChainManager
-      .executeChain(ChainType.Po, context)
-      .finally(() => {
-        setTimeout(() => {
-          FileLockStoreStore.getInstance().delete(
-            extractedFileParts.outputPath
-          );
-        }, 250);
-      });
+    PoFileChangeHandler.moduleChainManager.executeChain(ChainType.Po, context);
+
+    setTimeout(() => {
+      FileLockStoreStore.getInstance().delete(extractedFileParts.outputPath);
+    }, 250);
   }
 }


### PR DESCRIPTION
Reduce nested structure in PoFileChangeHandler to enhance readability 
and maintainability. Refactor file lock handling to run out of finalize 
block. Add sinon clock in tests for poFileChangeHandler and 
jsonFileChangeHandler to test the delay properly. Ensure stubs for 
fileLockStore methods are correctly restored in tests.