### PR TITLE
refactor: improve FilePathProcessor test structure

### DIFF
--- a/src/services/filePathProcessor.ts
+++ b/src/services/filePathProcessor.ts
@@ -21,10 +21,8 @@ export default class FilePathProcessor {
       );
     }
 
-    const isPOFile = filePath.endsWith('.po');
     const commonPath = filePath.replace(/\.po$|\.json$/, '');
-
-    return isPOFile
+    return filePath.endsWith('.po')
       ? Uri.file(`${commonPath}.json`)
       : Uri.file(`${commonPath}.po`);
   }

--- a/src/test/services/filePathProcessor.test.ts
+++ b/src/test/services/filePathProcessor.test.ts
@@ -1,43 +1,60 @@
 import * as assert from 'assert';
 import { Uri } from 'vscode';
 import FilePathProcessor from '../../services/filePathProcessor';
+import { ExtractedFileParts } from '../../types/extractedFileParts';
 
-suite('FilePathProcessor Tests', () => {
-  test('processFilePath should extract locale and output path for .po file', () => {
-    const filePath = 'C:\\path\\to\\locales\\en\\file.po';
-    const expectedLocale = 'en';
-    const expectedOutputPath = Uri.file('C:\\path\\to\\locales\\en\\file.json');
+suite('FilePathProcessor', () => {
+  suite('extractLocale', () => {
+    test('should extract locale from valid file path', () => {
+      const filePath = '\\path\\to\\locales\\en\\file.json';
+      const locale = FilePathProcessor['extractLocale'](filePath);
+      assert.strictEqual(locale, 'en');
+    });
 
-    const result = FilePathProcessor.processFilePath(filePath);
-
-    assert.strictEqual(result.locale, expectedLocale);
-    assert.deepStrictEqual(result.outputPath, expectedOutputPath);
+    test('should throw an error for invalid file path format', () => {
+      const filePath = '\\path\\to\\file.json';
+      assert.throws(() => {
+        FilePathProcessor['extractLocale'](filePath);
+      }, Error('Invalid file path format'));
+    });
   });
 
-  test('processFilePath should extract locale and output path for .json file', () => {
-    const filePath = 'C:\\path\\to\\locales\\fr\\file.json';
-    const expectedLocale = 'fr';
-    const expectedOutputPath = Uri.file('C:\\path\\to\\locales\\fr\\file.po');
+  suite('determineOutputPath', () => {
+    test('should determine output path for .po file', () => {
+      const filePath = '\\path\\to\\file.po';
+      const outputPath = FilePathProcessor['determineOutputPath'](filePath);
+      assert.strictEqual(
+        outputPath.fsPath,
+        Uri.file('\\path\\to\\file.json').fsPath
+      );
+    });
 
-    const result = FilePathProcessor.processFilePath(filePath);
+    test('should determine output path for .json file', () => {
+      const filePath = '\\path\\to\\file.json';
+      const outputPath = FilePathProcessor['determineOutputPath'](filePath);
+      assert.strictEqual(
+        outputPath.fsPath,
+        Uri.file('\\path\\to\\file.po').fsPath
+      );
+    });
 
-    assert.strictEqual(result.locale, expectedLocale);
-    assert.deepStrictEqual(result.outputPath, expectedOutputPath);
+    test('should throw an error for unsupported file extension', () => {
+      const filePath = '\\path\\to\\file.txt';
+      assert.throws(() => {
+        FilePathProcessor['determineOutputPath'](filePath);
+      }, Error('Invalid file extension. Only .po and .json files are supported.'));
+    });
   });
 
-  test('processFilePath should throw an error for invalid file path format', () => {
-    const filePath = 'C:\\path\\to\\invalid\\file.txt';
-
-    assert.throws(() => {
-      FilePathProcessor.processFilePath(filePath);
-    }, Error);
-  });
-
-  test('processFilePath should throw an error for unsupported file extension', () => {
-    const filePath = 'C:\\path\\to\\locales\\es\\file.txt';
-
-    assert.throws(() => {
-      FilePathProcessor.processFilePath(filePath);
-    }, Error);
+  suite('processFilePath', () => {
+    test('should process file path and extract locale and output path', () => {
+      const filePath = '\\path\\to\\locales\\en\\file.po';
+      const result: ExtractedFileParts =
+        FilePathProcessor.processFilePath(filePath);
+      assert.deepStrictEqual(result, {
+        locale: 'en',
+        outputPath: Uri.file('\\path\\to\\locales\\en\\file.json'),
+      });
+    });
   });
 });


### PR DESCRIPTION
Refactor tests for FilePathProcessor: 
- Split tests into extractLocale, determineOutputPath, 
  and processFilePath suites for better structure.
- Add new tests for extractLocale and determineOutputPath 
  to validate edge cases.
- Remove redundant tests and optimize logic to enhance 
  readability and maintainability