### PR TITLE
ci: attest build provenance in workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,6 +21,9 @@ jobs:
     env:
       SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
     steps:
+      - name: Attest Build Provenance
+        uses: actions/attest-build-provenance@v1.3.1
+
       - name: Checkout
         uses: actions/checkout@v4
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,6 +9,8 @@ on:
 permissions:
   contents: write
   pull-requests: write
+  id-token: write
+  attestations: write
 
 jobs:
   build:


### PR DESCRIPTION
Add steps to attest build provenance using actions/attest-build-
provenance@v1.3.1. This enhances security by ensuring the integrity 
and authenticity of the build process.