### PR TITLE
ci: add release workflow to automate version releases

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -62,13 +62,25 @@ jobs:
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
 
+      - uses: google-github-actions/release-please-action@v4.1.0
+        id: release
+        with:
+          # this assumes that you have created a personal access token
+          # (PAT) and configured it as a GitHub action secret named
+          # `MY_RELEASE_PLEASE_TOKEN` (this secret name is not important).
+          token: ${{ secrets.RELEASE_PLEASE_KEY }}
+          # this is a built-in strategy in release-please, see "Action Inputs"
+          # for more options
+          release-type: node
+
       - name: Create Pre-release extension
         if: matrix.os == 'ubuntu-latest'
-        run: npx vsce package -o i18nWeave-vscode-${{ github.run_number }}.vsix --pre-release
+        run: npx vsce package -o i18nWeave-vscode-${{ steps.release.outputs.tag_name }}.vsix --pre-release
 
-      - name: Upload VSIX Artifact
-        if: matrix.os == 'ubuntu-latest' # Only upload artifact on Ubuntu where release job runs
-        uses: actions/upload-artifact@v4
-        with:
-          name: i18nWeave-vscode-${{ github.run_number }}-${{ matrix.os }}
-          path: i18nWeave-vscode-${{ github.run_number }}.vsix
+      - name: Upload Release Artifact
+        if: ${{ steps.release.outputs.release_created }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+          #TODO: Change version below
+        run: gh release upload ${{ steps.release.outputs.tag_name }} i18nWeave-vscode-${{ steps.release.outputs.tag_name }}.vsix

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,6 +9,8 @@ on:
 permissions:
   contents: write
   pull-requests: write
+  id-token: write
+  attestations: write
 
 jobs:
   build:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -61,3 +61,38 @@ jobs:
         uses: codecov/codecov-action@v4.0.1
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
+
+  release:
+    needs: build
+    name: Release
+    runs-on: ubuntu-latest
+    steps:
+      - uses: google-github-actions/release-please-action@v4.1.0
+        id: release
+        with:
+          # this assumes that you have created a personal access token
+          # (PAT) and configured it as a GitHub action secret named
+          # `MY_RELEASE_PLEASE_TOKEN` (this secret name is not important).
+          token: ${{ secrets.RELEASE_PLEASE_KEY }}
+          # this is a built-in strategy in release-please, see "Action Inputs"
+          # for more options
+          release-type: node
+
+      - name: Create Pre-release extension
+        run: npx vsce package -o i18nWeave-vscode-${{steps.release.outputs.tag_name}}.vsix --pre-release
+
+      - name: Upload extension
+        uses: actions/upload-artifact@v4
+        with:
+          name: i18nWeave-vscode-
+          path: i18nWeave-vscode-${{steps.release.outputs.tag_name}}.vsix
+
+      - name: Upload Release Artifact
+        if: ${{ steps.release.outputs.release_created }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+          #TODO: Change version below
+        run: gh release upload ${{ steps.release.outputs.tag_name }} i18nWeave-vscode-${{ steps.release.outputs.tag_name }}.vsix
+
+      # Add your release steps here

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,9 +23,6 @@ jobs:
     env:
       SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
     steps:
-      - name: Attest Build Provenance
-        uses: actions/attest-build-provenance@v1.3.1
-
       - name: Checkout
         uses: actions/checkout@v4
 
@@ -82,5 +79,9 @@ jobs:
         if: ${{ steps.release.outputs.release_created }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
         run: gh release upload ${{ steps.release.outputs.tag_name }} i18nWeave-vscode-${{ steps.release.outputs.tag_name }}.vsix
+
+      - name: Attest Build Provenance
+        uses: actions/attest-build-provenance@v1.3.1
+        with:
+          subject-path: i18nWeave-vscode-${{ steps.release.outputs.tag_name }}.vsix

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -63,11 +63,12 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
 
       - name: Create Pre-release extension
+        if: matrix.os == 'ubuntu-latest'
         run: npx vsce package -o i18nWeave-vscode-${{ github.run_number }}.vsix --pre-release
 
       - name: Upload VSIX Artifact
         if: matrix.os == 'ubuntu-latest' # Only upload artifact on Ubuntu where release job runs
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: i18nWeave-vscode-${{ github.run_number }}-${{ matrix.os }}
           path: i18nWeave-vscode-${{ github.run_number }}.vsix

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,6 +12,7 @@ permissions:
   id-token: write
   attestations: write
 
+# Should have a look at the matrices and which steps run on which OS.
 jobs:
   build:
     name: Build & Test
@@ -51,9 +52,6 @@ jobs:
       - name: Build
         run: npm run compile
 
-      #- name: Lint
-      #  run: npm run lint
-
       - name: Lint & Test
         if: matrix.os == 'macos-latest' || matrix.os == 'windows-latest'
         run: npm run test:clover
@@ -64,25 +62,28 @@ jobs:
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
 
-      - uses: google-github-actions/release-please-action@v4.1.0
-        if: matrix.os == 'ubuntu-latest'
+      # For now everything below is placed should eventually be moved to a separate release workflow.
+      # I couldn't get it to work. :'(
+      - name: Release Please Action
+        if: github.ref == 'refs/heads/main'
+        uses: google-github-actions/release-please-action@v4.1.0
         id: release
         with:
           token: ${{ secrets.RELEASE_PLEASE_KEY }}
           release-type: node
 
       - name: Create Pre-release extension
-        if: matrix.os == 'ubuntu-latest'
+        if: github.ref == 'refs/heads/main'
         run: npx vsce package -o i18nWeave-vscode-${{ steps.release.outputs.tag_name }}.vsix --pre-release
 
       - name: Upload Release Artifact
-        if: ${{ steps.release.outputs.release_created }}
+        if: github.ref == 'refs/heads/main' && steps.release.outputs.release_created
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: gh release upload ${{ steps.release.outputs.tag_name }} i18nWeave-vscode-${{ steps.release.outputs.tag_name }}.vsix
 
       - name: Attest Build Provenance
-        if: matrix.os == 'ubuntu-latest'
+        if: github.ref == 'refs/heads/main'
         uses: actions/attest-build-provenance@v1.3.1
         with:
           subject-path: i18nWeave-vscode-${{ steps.release.outputs.tag_name }}.vsix

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -63,14 +63,10 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
 
       - uses: google-github-actions/release-please-action@v4.1.0
+        if: matrix.os == 'ubuntu-latest'
         id: release
         with:
-          # this assumes that you have created a personal access token
-          # (PAT) and configured it as a GitHub action secret named
-          # `MY_RELEASE_PLEASE_TOKEN` (this secret name is not important).
           token: ${{ secrets.RELEASE_PLEASE_KEY }}
-          # this is a built-in strategy in release-please, see "Action Inputs"
-          # for more options
           release-type: node
 
       - name: Create Pre-release extension
@@ -82,5 +78,4 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-          #TODO: Change version below
         run: gh release upload ${{ steps.release.outputs.tag_name }} i18nWeave-vscode-${{ steps.release.outputs.tag_name }}.vsix

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -62,37 +62,9 @@ jobs:
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
 
-  release:
-    needs: build
-    name: Release
-    runs-on: ubuntu-latest
-    steps:
-      - uses: google-github-actions/release-please-action@v4.1.0
-        id: release
+      - name: Upload VSIX Artifact
+        if: matrix.os == 'ubuntu-latest' # Only upload artifact on Ubuntu where release job runs
+        uses: actions/upload-artifact@v2
         with:
-          # this assumes that you have created a personal access token
-          # (PAT) and configured it as a GitHub action secret named
-          # `MY_RELEASE_PLEASE_TOKEN` (this secret name is not important).
-          token: ${{ secrets.RELEASE_PLEASE_KEY }}
-          # this is a built-in strategy in release-please, see "Action Inputs"
-          # for more options
-          release-type: node
-
-      - name: Create Pre-release extension
-        run: npx vsce package -o i18nWeave-vscode-${{steps.release.outputs.tag_name}}.vsix --pre-release
-
-      - name: Upload extension
-        uses: actions/upload-artifact@v4
-        with:
-          name: i18nWeave-vscode-
-          path: i18nWeave-vscode-${{steps.release.outputs.tag_name}}.vsix
-
-      - name: Upload Release Artifact
-        if: ${{ steps.release.outputs.release_created }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-          #TODO: Change version below
-        run: gh release upload ${{ steps.release.outputs.tag_name }} i18nWeave-vscode-${{ steps.release.outputs.tag_name }}.vsix
-
-      # Add your release steps here
+          name: i18nWeave-vscode-${{ github.run_number }}-${{ matrix.os }}
+          path: i18nWeave-vscode-${{ github.run_number }}.vsix

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -82,6 +82,7 @@ jobs:
         run: gh release upload ${{ steps.release.outputs.tag_name }} i18nWeave-vscode-${{ steps.release.outputs.tag_name }}.vsix
 
       - name: Attest Build Provenance
+        if: matrix.os == 'ubuntu-latest'
         uses: actions/attest-build-provenance@v1.3.1
         with:
           subject-path: i18nWeave-vscode-${{ steps.release.outputs.tag_name }}.vsix

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -62,6 +62,9 @@ jobs:
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
 
+      - name: Create Pre-release extension
+        run: npx vsce package -o i18nWeave-vscode-${{ github.run_number }}.vsix --pre-release
+
       - name: Upload VSIX Artifact
         if: matrix.os == 'ubuntu-latest' # Only upload artifact on Ubuntu where release job runs
         uses: actions/upload-artifact@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,6 +23,9 @@ jobs:
     env:
       SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
     steps:
+      - name: Attest Build Provenance
+        uses: actions/attest-build-provenance@v1.3.1
+
       - name: Checkout
         uses: actions/checkout@v4
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,12 +13,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Download VSIX Artifact
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v4
         with:
           name: i18nWeave-vscode-${{ github.run_number }}-ubuntu-latest
 
       - name: Upload extension
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: i18nWeave-vscode-${{ github.run_number }}-${{ github.run_number }}-ubuntu-latest
           path: i18nWeave-vscode-${{ github.run_number }}.vsix

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,9 +17,6 @@ jobs:
         with:
           name: i18nWeave-vscode-${{ github.run_number }}-ubuntu-latest
 
-      - name: Create Pre-release extension
-        run: npx vsce package -o i18nWeave-vscode-${{ github.run_number }}.vsix --pre-release
-
       - name: Upload extension
         uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,32 @@
+name: Release
+
+on:
+  workflow_run:
+    workflows: ['Build & Test']
+    types:
+      - completed
+
+jobs:
+  release:
+    name: Release
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download VSIX Artifact
+        uses: actions/download-artifact@v2
+        with:
+          name: i18nWeave-vscode-${{ github.run_number }}-ubuntu-latest
+
+      - name: Create Pre-release extension
+        run: npx vsce package -o i18nWeave-vscode-${{ github.run_number }}.vsix --pre-release
+
+      - name: Upload extension
+        uses: actions/upload-artifact@v2
+        with:
+          name: i18nWeave-vscode-${{ github.run_number }}-${{ github.run_number }}-ubuntu-latest
+          path: i18nWeave-vscode-${{ github.run_number }}.vsix
+
+      - name: Upload Release Artifact
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh release upload ${{ github.run_number }} i18nWeave-vscode-${{ github.run_number }}.vsix

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,18 +12,46 @@ jobs:
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
     steps:
+      - uses: google-github-actions/release-please-action@v4.1.0
+        id: release
+        with:
+          # this assumes that you have created a personal access token
+          # (PAT) and configured it as a GitHub action secret named
+          # `MY_RELEASE_PLEASE_TOKEN` (this secret name is not important).
+          token: ${{ secrets.RELEASE_PLEASE_KEY }}
+          # this is a built-in strategy in release-please, see "Action Inputs"
+          # for more options
+          release-type: node
+
       - name: Download VSIX Artifact
         uses: actions/download-artifact@v4
         with:
           name: i18nWeave-vscode-${{ github.run_number }}-ubuntu-latest
 
-      - name: Upload extension
-        uses: actions/upload-artifact@v4
-        with:
-          name: i18nWeave-vscode-${{ github.run_number }}-${{ github.run_number }}-ubuntu-latest
-          path: i18nWeave-vscode-${{ github.run_number }}.vsix
+      # - name: Upload extension
+      #   uses: actions/upload-artifact@v4
+      #   with:
+      #     name: i18nWeave-vscode-${{ github.run_number }}-${{ github.run_number }}-ubuntu-latest
+      #     path: i18nWeave-vscode-${{ github.run_number }}.vsix
+
+      # - name: Upload Release Artifact
+      #   env:
+      #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      #   run: gh release upload ${{ github.run_number }} i18nWeave-vscode-${{ github.run_number }}.vsix
+
+      # - name: Create Pre-release extension
+      #   run: npx vsce package -o i18nWeave-vscode-${{steps.release.outputs.tag_name}}.vsix --pre-release
+
+      # - name: Upload extension
+      #   uses: actions/upload-artifact@v4
+      #   with:
+      #     name: i18nWeave-vscode-
+      #     path: i18nWeave-vscode-${{ github.run_number }}-ubuntu-latest
 
       - name: Upload Release Artifact
+        if: ${{ steps.release.outputs.release_created }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh release upload ${{ github.run_number }} i18nWeave-vscode-${{ github.run_number }}.vsix
+
+          #TODO: Change version below
+        run: gh release upload ${{ steps.release.outputs.tag_name }} i18nWeave-vscode-${{ steps.release.outputs.tag_name }}.vsix


### PR DESCRIPTION
Integrate `release-please-action` to handle automated versioning,
create a pre-release extension, and upload release artifacts. This
enhancement streamlines the release process, ensuring consistency 
and reducing manual intervention.