### PR TITLE
chore: switch to actions/upload-artifact for extension upload

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -63,10 +63,11 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
 
       - name: Create Pre-release extension
-        if: github.ref == 'refs/heads/main'
+        # if: github.ref == 'refs/heads/main'
         run: npx vsce package -o i18nWeave-vscode-${{ github.run_number }}.vsix --pre-release
 
       - name: Upload extension
+        # if: github.ref == 'refs/heads/main'
         uses: actions/upload-artifact@v4
         with:
           name: i18nWeave-vscode

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -63,13 +63,13 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
 
       - name: Create Pre-release extension
-        # if: github.ref == 'refs/heads/main' && matrix.os == 'ubuntu-latest'
-        if: matrix.os == 'ubuntu-latest'
+        if: github.ref == 'refs/heads/main' && matrix.os == 'ubuntu-latest'
+        # if: matrix.os == 'ubuntu-latest'
         run: npx vsce package -o i18nWeave-vscode-${{ github.run_number }}.vsix --pre-release
 
       - name: Upload extension
-        # if: github.ref == 'refs/heads/main' && matrix.os == 'ubuntu-latest'
-        if: matrix.os == 'ubuntu-latest'
+        if: github.ref == 'refs/heads/main' && matrix.os == 'ubuntu-latest'
+        # if: matrix.os == 'ubuntu-latest'
         uses: actions/upload-artifact@v4
         with:
           name: i18nWeave-vscode

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -63,11 +63,13 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
 
       - name: Create Pre-release extension
-        # if: github.ref == 'refs/heads/main'
+        # if: github.ref == 'refs/heads/main' && matrix.os == 'ubuntu-latest'
+        if: matrix.os == 'ubuntu-latest'
         run: npx vsce package -o i18nWeave-vscode-${{ github.run_number }}.vsix --pre-release
 
       - name: Upload extension
-        # if: github.ref == 'refs/heads/main'
+        # if: github.ref == 'refs/heads/main' && matrix.os == 'ubuntu-latest'
+        if: matrix.os == 'ubuntu-latest'
         uses: actions/upload-artifact@v4
         with:
           name: i18nWeave-vscode

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -66,8 +66,14 @@ jobs:
         if: github.ref == 'refs/heads/main'
         run: npx vsce package -o i18nWeave-vscode-${{ github.run_number }}.vsix --pre-release
 
-      - name: Upload Release Artifact
-        if: github.ref == 'refs/heads/main'
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh release upload ${{ github.run_number }} i18nWeave-vscode-${{ github.run_number }}.vsix
+      - name: Upload extension
+        uses: actions/upload-artifact@v4
+        with:
+          name: i18nWeave-vscode
+          path: i18nWeave-vscode-${{ github.run_number }}.vsix
+
+      # - name: Upload Release Artifact
+      #   if: github.ref == 'refs/heads/main'
+      #   env:
+      #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      #   run: gh release upload ${{ github.run_number }} i18nWeave-vscode-${{ github.run_number }}.vsix

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,7 @@ name: Release
 on:
   workflow_run:
     workflows: ['Build & Test']
-    # branches: [main]
+    branches: [main]
     types:
       - completed
 


### PR DESCRIPTION
Replace the upload step in build workflow with actions/upload-artifact
to simplify and standardize the process. Comment out deprecated code 
using gh release upload.