### PR TITLE
fix(workflow): correct artifact download in release job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,6 +33,7 @@ jobs:
         uses: dawidd6/action-download-artifact@v6
         with:
           name: i18nWeave-vscode
+          workflow: build.yml
       #        path: i18nWeave-vscode.vsix
 
       # - name: Upload extension


### PR DESCRIPTION
Add missing 'workflow: build.yml' in the release workflow to ensure
the proper artifact is downloaded. This change is necessary to
align with the build process and guarantee the correct files are
used during the release.