### PR TITLE
fix: add permissions configuration to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,9 @@ on:
     types:
       - completed
 
+permissions:
+  contents: write
+
 jobs:
   release:
     name: Release


### PR DESCRIPTION
Add 'contents: write' permissions to the GitHub Actions release
workflow to ensure proper access for deployment processes. This change
is necessary to prevent permission-related errors during the release
job execution.