### PR TITLE
chore: update workflows to include SBOM and attestation

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,9 +8,6 @@ on:
 
 permissions:
   pull-requests: write
-  # todo: remove
-  id-token: write
-  attestations: write
 
 # Should have a look at the matrices and which steps run on which OS.
 jobs:
@@ -33,60 +30,31 @@ jobs:
           node-version: 20
           cache: 'npm'
 
-      # - name: Cache VS Code Versions
-      #   id: cache-vscode
-      #   uses: actions/cache@v4
-      #   with:
-      #     path: .vscode-test/
-      #     key: ${{ runner.os }}-vscode-test-${{ hashFiles('**/src/*.ts', 'vscode-stable-versions.json') }}
-      #     restore-keys: |
-      #       ${{ runner.os }}-vscode-test-
+      - name: Cache VS Code Versions
+        id: cache-vscode
+        uses: actions/cache@v4
+        with:
+          path: .vscode-test/
+          key: ${{ runner.os }}-vscode-test-${{ hashFiles('**/src/*.ts', 'vscode-stable-versions.json') }}
+          restore-keys: |
+            ${{ runner.os }}-vscode-test-
 
-      # - name: Get VS Code Versions
-      #   if: steps.cache-vscode.outputs.cache-hit != 'true'
-      #   run: curl --output vscode-stable-versions.json https://update.code.visualstudio.com/api/releases/stable
+      - name: Get VS Code Versions
+        if: steps.cache-vscode.outputs.cache-hit != 'true'
+        run: curl --output vscode-stable-versions.json https://update.code.visualstudio.com/api/releases/stable
 
       - name: Install dependencies
         run: npm install
 
       - name: Build
-        run: npm run compile #:sourcemaps
+        run: npm run compile:sourcemaps
 
-      # - name: Lint & Test
-      #   if: matrix.os == 'macos-latest' || matrix.os == 'windows-latest'
-      #   run: npm run test:clover
+      - name: Lint & Test
+        if: matrix.os == 'macos-latest' || matrix.os == 'windows-latest'
+        run: npm run test:clover
 
-      # - name: Upload coverage reports to Codecov
-      #   if: matrix.os == 'macos-latest' || matrix.os == 'windows-latest'
-      #   uses: codecov/codecov-action@v4.0.1
-      #   with:
-      #     token: ${{ secrets.CODECOV_TOKEN }}
-
-      # todo: remvoe below lines
-
-      - name: Generate SBOM
-        uses: anchore/sbom-action@v0
+      - name: Upload coverage reports to Codecov
+        if: matrix.os == 'macos-latest' || matrix.os == 'windows-latest'
+        uses: codecov/codecov-action@v4.0.1
         with:
-          path: 'out'
-          format: 'spdx-json'
-          output-file: 'sbom.spdx.json'
-
-      - name: Attest SBOM
-        uses: actions/attest-sbom@v1
-        with:
-          subject-path: '${{ github.workspace }}/out'
-          sbom-path: 'sbom.spdx.json'
-
-      # - name: Upload extension
-      #   if: github.ref == 'refs/heads/main' && matrix.os == 'ubuntu-latest'
-      #   # if: matrix.os == 'ubuntu-latest'
-      #   uses: actions/upload-artifact@v4
-      #   with:
-      #     name: i18nWeave-vscode
-      #     path: i18nWeave-vscode.vsix
-
-      # - name: Upload Release Artifact
-      #   if: github.ref == 'refs/heads/main'
-      #   env:
-      #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      #   run: gh release upload ${{ github.run_number }} i18nWeave-vscode-${{ github.run_number }}.vsix
+          token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,8 +7,8 @@ on:
       - main
 
 permissions:
-  contents: write
   pull-requests: write
+  # todo: remove
   id-token: write
   attestations: write
 
@@ -33,34 +33,49 @@ jobs:
           node-version: 20
           cache: 'npm'
 
-      - name: Cache VS Code Versions
-        id: cache-vscode
-        uses: actions/cache@v4
-        with:
-          path: .vscode-test/
-          key: ${{ runner.os }}-vscode-test-${{ hashFiles('**/src/*.ts', 'vscode-stable-versions.json') }}
-          restore-keys: |
-            ${{ runner.os }}-vscode-test-
+      # - name: Cache VS Code Versions
+      #   id: cache-vscode
+      #   uses: actions/cache@v4
+      #   with:
+      #     path: .vscode-test/
+      #     key: ${{ runner.os }}-vscode-test-${{ hashFiles('**/src/*.ts', 'vscode-stable-versions.json') }}
+      #     restore-keys: |
+      #       ${{ runner.os }}-vscode-test-
 
-      - name: Get VS Code Versions
-        if: steps.cache-vscode.outputs.cache-hit != 'true'
-        run: curl --output vscode-stable-versions.json https://update.code.visualstudio.com/api/releases/stable
+      # - name: Get VS Code Versions
+      #   if: steps.cache-vscode.outputs.cache-hit != 'true'
+      #   run: curl --output vscode-stable-versions.json https://update.code.visualstudio.com/api/releases/stable
 
       - name: Install dependencies
         run: npm install
 
       - name: Build
-        run: npm run compile:sourcemaps
+        run: npm run compile #:sourcemaps
 
-      - name: Lint & Test
-        if: matrix.os == 'macos-latest' || matrix.os == 'windows-latest'
-        run: npm run test:clover
+      # - name: Lint & Test
+      #   if: matrix.os == 'macos-latest' || matrix.os == 'windows-latest'
+      #   run: npm run test:clover
 
-      - name: Upload coverage reports to Codecov
-        if: matrix.os == 'macos-latest' || matrix.os == 'windows-latest'
-        uses: codecov/codecov-action@v4.0.1
+      # - name: Upload coverage reports to Codecov
+      #   if: matrix.os == 'macos-latest' || matrix.os == 'windows-latest'
+      #   uses: codecov/codecov-action@v4.0.1
+      #   with:
+      #     token: ${{ secrets.CODECOV_TOKEN }}
+
+      # todo: remvoe below lines
+
+      - name: Generate SBOM
+        uses: anchore/sbom-action@v0
         with:
-          token: ${{ secrets.CODECOV_TOKEN }}
+          path: 'out'
+          format: 'spdx-json'
+          output-file: 'sbom.spdx.json'
+
+      - name: Attest SBOM
+        uses: actions/attest-sbom@v1
+        with:
+          subject-path: '${{ github.workspace }}/out'
+          sbom-path: 'sbom.spdx.json'
 
       # - name: Upload extension
       #   if: github.ref == 'refs/heads/main' && matrix.os == 'ubuntu-latest'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,8 @@ on:
 
 permissions:
   contents: write
+  id-token: write
+  attestations: write
 
 jobs:
   release:
@@ -46,3 +48,24 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: gh release upload ${{steps.release.outputs.tag_name}} i18nWeave-vscode-${{steps.release.outputs.tag_name}}.vsix
+
+      - name: Attest Build Provenance
+        if: ${{ steps.release.outputs.release_created }}
+        uses: actions/attest-build-provenance@v1.3.1
+        with:
+          subject-path: i18nWeave-vscode-${{ steps.release.outputs.tag_name }}.vsix
+
+      - name: Generate SBOM
+        if: ${{ steps.release.outputs.release_created }}
+        uses: anchore/sbom-action@v0
+        with:
+          path: 'out'
+          format: 'spdx-json'
+          output-file: 'sbom.spdx.json'
+
+      - name: Attest SBOM
+        if: ${{ steps.release.outputs.release_created }}
+        uses: actions/attest-sbom@v1
+        with:
+          subject-path: '${{ github.workspace }}/out'
+          sbom-path: 'sbom.spdx.json'


### PR DESCRIPTION
Add id-token and attestations permissions in release workflow. 
Add steps for
generating and attesting SBOM in both build and release workflows
to enhance software supply chain security.