### PR TITLE
fix(ci): update release-please-action and add manifest

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,7 @@ jobs:
           node-version: 20
           cache: 'npm'
 
-      - uses: google-github-actions/release-please-action@v4.1.0
+      - uses: googleapis/release-please-action@v4
         id: release
         with:
           token: ${{ secrets.RELEASE_PLEASE_KEY }}

--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,0 +1,3 @@
+{
+  "prerelease": true
+}


### PR DESCRIPTION
Update release-please-action to use googleapis/release-please-
action@v4 for improved maintenance.
Add .release-please-
manifest.json file to enable prerelease versions.