### PR TITLE
refactor: update file path utilities usage and tests

### DIFF
--- a/src/lib/services/fileChange/fileChangeHandlers/jsonFileChangeHandler.test.ts
+++ b/src/lib/services/fileChange/fileChangeHandlers/jsonFileChangeHandler.test.ts
@@ -7,7 +7,7 @@ import ModuleChainManager from '../../../modules/moduleChainManager';
 import ReadJsonFileModule from '../../../modules/readJsonFile/readJsonFileModule';
 import TranslationModule from '../../../modules/translation/translationModule';
 import FileLockStoreStore from '../../../stores/fileLock/fileLockStore';
-import filePathUtilities from '../../../utilities/filePathUtilities';
+import * as filePathUtilities from '../../../utilities/filePathUtilities';
 import FileWatcherCreator from '../fileWatcherCreator';
 import JsonFileChangeHandler from './jsonFileChangeHandler';
 
@@ -73,9 +73,11 @@ suite('JsonFileChangeHandler', () => {
       outputPath: Uri.parse('/path/to/output'),
     };
 
-    const processFilePathStub = sinon
-      .stub(filePathUtilities, 'processFilePath')
-      .returns(extractedFileParts);
+    const extractFilePathPartsStub = sinon.stub(
+      filePathUtilities,
+      'extractFilePathParts'
+    );
+    extractFilePathPartsStub.returns(extractedFileParts);
 
     const fileWatcherCreatorCreateFileWatcherForFileStub = sinon.stub(
       FileWatcherCreator.prototype,
@@ -96,7 +98,7 @@ suite('JsonFileChangeHandler', () => {
     );
 
     sinon.assert.calledOnceWithExactly(
-      processFilePathStub,
+      extractFilePathPartsStub,
       changeFileLocation.fsPath
     );
 
@@ -117,7 +119,7 @@ suite('JsonFileChangeHandler', () => {
 
     sinon.assert.calledOnce(fileWatcherCreatorCreateFileWatcherForFileStub);
 
-    processFilePathStub.restore();
+    extractFilePathPartsStub.restore();
     moduleChainManagerExecuteChainStub.restore();
     fileLockStoreAddStub.restore();
     fileWatcherCreatorCreateFileWatcherForFileStub.restore();

--- a/src/lib/services/fileChange/fileChangeHandlers/jsonFileChangeHandler.ts
+++ b/src/lib/services/fileChange/fileChangeHandlers/jsonFileChangeHandler.ts
@@ -10,7 +10,7 @@ import ModuleChainManager from '../../../modules/moduleChainManager';
 import ReadJsonFileModule from '../../../modules/readJsonFile/readJsonFileModule';
 import TranslationModule from '../../../modules/translation/translationModule';
 import FileLockStoreStore from '../../../stores/fileLock/fileLockStore';
-import FilePathUtilities from '../../../utilities/filePathUtilities';
+import { extractFilePathParts } from '../../../utilities/filePathUtilities';
 import FileWatcherCreator from '../fileWatcherCreator';
 
 export default class JsonFileChangeHandler implements FileChangeHandler {
@@ -92,7 +92,7 @@ export default class JsonFileChangeHandler implements FileChangeHandler {
           return Promise.resolve();
         }
 
-        const extractedFileParts = FilePathUtilities.processFilePath(
+        const extractedFileParts = extractFilePathParts(
           changeFileLocation.fsPath
         );
 

--- a/src/lib/services/fileChange/fileChangeHandlers/poFileChangeHandler.test.ts
+++ b/src/lib/services/fileChange/fileChangeHandlers/poFileChangeHandler.test.ts
@@ -6,7 +6,7 @@ import { ChainType } from '../../../enums/chainType';
 import ModuleChainManager from '../../../modules/moduleChainManager';
 import ReadPoFileModule from '../../../modules/readPoFile/readPoFileModule';
 import FileLockStoreStore from '../../../stores/fileLock/fileLockStore';
-import filePathUtilities from '../../../utilities/filePathUtilities';
+import * as filePathUtilities from '../../../utilities/filePathUtilities';
 import FileWatcherCreator from '../fileWatcherCreator';
 import PoFileChangeHandler from './poFileChangeHandler';
 
@@ -65,9 +65,11 @@ suite('PoFileChangeHandler', () => {
       outputPath: Uri.parse('/path/to/output'),
     };
 
-    const processFilePathStub = sinon
-      .stub(filePathUtilities, 'processFilePath')
-      .returns(extractedFileParts);
+    const extractFilePathPartsStub = sinon.stub(
+      filePathUtilities,
+      'extractFilePathParts'
+    );
+    extractFilePathPartsStub.returns(extractedFileParts);
 
     const fileWatcherCreatorCreateFileWatcherForFileStub = sinon.stub(
       FileWatcherCreator.prototype,
@@ -88,7 +90,7 @@ suite('PoFileChangeHandler', () => {
     );
 
     sinon.assert.calledOnceWithExactly(
-      processFilePathStub,
+      extractFilePathPartsStub,
       changeFileLocation.fsPath
     );
 
@@ -109,7 +111,7 @@ suite('PoFileChangeHandler', () => {
 
     sinon.assert.calledOnce(fileWatcherCreatorCreateFileWatcherForFileStub);
 
-    processFilePathStub.restore();
+    extractFilePathPartsStub.restore();
     moduleChainManagerExecuteChainStub.restore();
     fileLockStoreAddStub.restore();
     fileWatcherCreatorCreateFileWatcherForFileStub.restore();

--- a/src/lib/services/fileChange/fileChangeHandlers/poFileChangeHandler.ts
+++ b/src/lib/services/fileChange/fileChangeHandlers/poFileChangeHandler.ts
@@ -9,7 +9,7 @@ import ModuleChainManager from '../../../modules/moduleChainManager';
 import PoToI18nextJsonConversionModule from '../../../modules/poToI18nextJsonConversion/poToI18nextJsonConversionModule';
 import ReadPoFileModule from '../../../modules/readPoFile/readPoFileModule';
 import FileLockStoreStore from '../../../stores/fileLock/fileLockStore';
-import FilePathUtilities from '../../../utilities/filePathUtilities';
+import { extractFilePathParts } from '../../../utilities/filePathUtilities';
 import FileWatcherCreator from '../fileWatcherCreator';
 
 export default class PoFileChangeHandler implements FileChangeHandler {
@@ -81,7 +81,7 @@ export default class PoFileChangeHandler implements FileChangeHandler {
           return Promise.resolve();
         }
 
-        const extractedFileParts = FilePathUtilities.processFilePath(
+        const extractedFileParts = extractFilePathParts(
           changeFileLocation.fsPath
         );
 

--- a/src/lib/utilities/filePathUtilities.test.ts
+++ b/src/lib/utilities/filePathUtilities.test.ts
@@ -1,61 +1,77 @@
-import * as assert from 'assert';
-import { Uri } from 'vscode';
+import assert from 'assert';
+import vscode from 'vscode';
 
-import { ExtractedFileParts } from '../types/extractedFileParts';
-import FilePathUtilities from './filePathUtilities';
+import {
+  determineOutputPath,
+  extractFilePathParts,
+  extractLocale,
+  getFileExtension,
+} from './filePathUtilities';
 
-suite('FilePathUtilities', () => {
+suite('filePathUtilities', () => {
   suite('extractLocale', () => {
-    test('should extract locale from valid file path', () => {
-      const filePath = '\\path\\to\\locales\\en\\file.json';
-      const locale = FilePathUtilities['extractLocale'](filePath);
-      assert.strictEqual(locale, 'en');
+    test('should extract the locale from the file path', () => {
+      const filePath = 'C:\\locales\\en\\file.po';
+      const locale = extractLocale(filePath);
+      assert.equal(locale, 'en');
     });
 
     test('should throw an error for invalid file path format', () => {
-      const filePath = '\\path\\to\\file.json';
-      assert.throws(() => {
-        FilePathUtilities['extractLocale'](filePath);
-      }, Error('Invalid file path format'));
+      const filePath = 'C:\\invalid\\file.path';
+      assert.throws(() => extractLocale(filePath), {
+        message: 'Invalid file path format',
+      });
     });
   });
 
   suite('determineOutputPath', () => {
-    test('should determine output path for .po file', () => {
-      const filePath = '\\path\\to\\file.po';
-      const outputPath = FilePathUtilities['determineOutputPath'](filePath);
-      assert.strictEqual(
-        outputPath.fsPath,
-        Uri.file('\\path\\to\\file.json').fsPath
+    test('should determine the output path for .po file', () => {
+      const filePath = 'C:\\locales\\en\\file.po';
+      const outputPath = determineOutputPath(filePath);
+      assert.deepStrictEqual(
+        outputPath,
+        vscode.Uri.file('C:\\locales\\en\\file.json')
       );
     });
 
-    test('should determine output path for .json file', () => {
-      const filePath = '\\path\\to\\file.json';
-      const outputPath = FilePathUtilities['determineOutputPath'](filePath);
-      assert.strictEqual(
-        outputPath.fsPath,
-        Uri.file('\\path\\to\\file.po').fsPath
+    test('should determine the output path for .json file', () => {
+      const filePath = 'C:\\locales\\en\\file.json';
+      const outputPath = determineOutputPath(filePath);
+
+      assert.deepStrictEqual(
+        outputPath,
+        vscode.Uri.file('C:\\locales\\en\\file.po')
       );
     });
 
-    test('should throw an error for unsupported file extension', () => {
-      const filePath = '\\path\\to\\file.txt';
-      assert.throws(() => {
-        FilePathUtilities['determineOutputPath'](filePath);
-      }, Error('Invalid file extension. Only .po and .json files are supported.'));
+    test('should throw an error for invalid file extension', () => {
+      const filePath = 'C:\\locales\\en\\file.txt';
+
+      assert.throws(() => determineOutputPath(filePath), {
+        message:
+          'Invalid file extension. Only .po and .json files are supported.',
+      });
     });
   });
 
-  suite('processFilePath', () => {
-    test('should process file path and extract locale and output path', () => {
-      const filePath = '\\path\\to\\locales\\en\\file.po';
-      const result: ExtractedFileParts =
-        FilePathUtilities.processFilePath(filePath);
-      assert.deepStrictEqual(result, {
+  suite('extractFilePathParts', () => {
+    test('should extract the locale and output path from the file path', () => {
+      const filePath = 'C:\\locales\\en\\file.po';
+      const filePathParts = extractFilePathParts(filePath);
+
+      assert.deepStrictEqual(filePathParts, {
         locale: 'en',
-        outputPath: Uri.file('\\path\\to\\locales\\en\\file.json'),
+        outputPath: vscode.Uri.file('C:\\locales\\en\\file.json'),
       });
+    });
+  });
+
+  suite('getFileExtension', () => {
+    test('should get the file extension from the URI', () => {
+      const uri = vscode.Uri.file('C:\\locales\\en\\file.po');
+      const fileExtension = getFileExtension(uri);
+
+      assert.strictEqual(fileExtension, 'po');
     });
   });
 });


### PR DESCRIPTION
Replace processFilePath with extractFilePathParts to standardize
naming conventions across file change handlers. Adjust corresponding
imports and stub restoration to align with the new utility function.
Streamline tests by refactoring filePathUtilities imports and using
vscode assertions.