### PR TITLE
fix(codecov): correct typo in ignore path

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -33,4 +33,4 @@ ignore:
   - 'src/lib/enums/*.ts'
   - 'src/extension.ts'
   - 'src/media/**/*'
-  - '**/jsonWebviewCreator.ts
+  - '**/jsonWebviewCreator.ts'


### PR DESCRIPTION
Correct a misplaced quote in the codecov ignore path entry to
ensure accurate path recognition during coverage reporting.