### PR TITLE
feat: enhance i18n support and simplify config

### DIFF
--- a/package.json
+++ b/package.json
@@ -143,8 +143,87 @@
         "properties": {
           "i18nWeave.i18nextScannerModule.enabled": {
             "type": "boolean",
-            "default": false,
+            "default": true,
             "description": "Enable the i18next-scanner module."
+          },
+          "i18nWeave.i18nextScannerModule.namespaces": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "default": [
+              "common"
+            ],
+            "description": "List of namespaces for translation."
+          },
+          "i18nWeave.i18nextScannerModule.defaultNamespace": {
+            "type": "string",
+            "default": "common",
+            "description": "Default namespace to use for translations."
+          },
+          "i18nWeave.i18nextScannerModule.codeFileLocations": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "default": [
+              "src"
+            ],
+            "description": "List of code file locations to scan."
+          },
+          "i18nWeave.i18nextScannerModule.translationFilesLocation": {
+            "type": "string",
+            "default": "src/i18n",
+            "description": "Location of the translation files."
+          },
+          "i18nWeave.i18nextScannerModule.languages": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "default": [
+              "en"
+            ],
+            "description": "Languages used by your application."
+          },
+          "i18nWeave.i18nextScannerModule.defaultLanguage": {
+            "type": "string",
+            "default": "en",
+            "description": "Default language used by your application."
+          },
+          "i18nWeave.i18nextScannerModule.translationFunctionNames": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "default": [
+              "t",
+              "i18next.t"
+            ],
+            "description": "Names of the translation functions used in your application."
+          },
+          "i18nWeave.i18nextScannerModule.translationComponentTranslationKey": {
+            "type": "string",
+            "default": "i18nKey",
+            "description": "Names of the translation functions used in your application."
+          },
+          "i18nWeave.i18nextScannerModule.translationComponentName": {
+            "type": "string",
+            "default": "Trans",
+            "description": "Name of the translation component used in your application."
+          },
+          "i18nWeave.i18nextScannerModule.fileExtensions": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "default": [
+              ".ts",
+              ".tsx",
+              ".js",
+              ".jsx"
+            ],
+            "description": "File extensions to scan for translations."
           }
         }
       },
@@ -152,11 +231,6 @@
         "id": "general",
         "title": "General",
         "properties": {
-          "i18nWeave.pathsConfiguration.packageJsonAbsoluteFolderPath": {
-            "type": "string",
-            "default": "",
-            "description": "Absolute Path to the package.json file of your project."
-          },
           "i18nWeave.betaFeaturesConfiguration.enableJsonFileWebView": {
             "type": "boolean",
             "default": false,

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -37,20 +37,23 @@ export async function activate(
 
   _context = context;
 
+  const tempHardCodedTransFilesPath = 'src/i18n'; //old val: public/locales
+  const tempHardCodedCodeFilesPath = 'src'; //old val: {apps,libs}
+
   try {
     const fileSearchLocations = [
       {
-        filePattern: '**/public/locales/**/*.json',
+        filePattern: `**/${tempHardCodedTransFilesPath}/**/*.json`,
         ignorePattern:
           '{**/node_modules/**,**/.next/**,**/.git/**,**/.nx/**,**/.coverage/**,**/.cache/**}',
       } as FileSearchLocation,
       {
-        filePattern: '**/public/locales/**/*.po',
+        filePattern: `**/${tempHardCodedTransFilesPath}/**/*.po`,
         ignorePattern:
           '**/node_modules/**,**/.next/**,**/.git/**,**/.nx/**,**/.coverage/**,**/.cache/**',
       } as FileSearchLocation,
       {
-        filePattern: '**/{apps,libs}/**/*.{tsx,ts}',
+        filePattern: `**/${tempHardCodedCodeFilesPath}/**/*.{tsx,ts}`,
         ignorePattern:
           '{**/node_modules/**,**/.next/**,**/.git/**,**/.nx/**,**/.coverage/**,**/.cache/**,**/*.spec.ts,**/*.spec.tsx}',
       } as FileSearchLocation,

--- a/src/lib/entities/configuration/general/generalConfiguration.ts
+++ b/src/lib/entities/configuration/general/generalConfiguration.ts
@@ -1,11 +1,9 @@
 import BetaFeaturesConfiguration from './betaFeaturesConfiguration';
-import PathsConfiguration from './pathsConfiguration';
 
 /**
  * Represents the general extension configuration used during the extension's runtime.
  */
 export default class GeneralConfiguration {
-  pathsConfiguration: PathsConfiguration = new PathsConfiguration();
   betaFeaturesConfiguration: BetaFeaturesConfiguration =
     new BetaFeaturesConfiguration();
 }

--- a/src/lib/entities/configuration/general/pathsConfiguration.ts
+++ b/src/lib/entities/configuration/general/pathsConfiguration.ts
@@ -1,6 +1,0 @@
-/**
- * Represents the configuration for the paths to specific files used during the extension's runtime.
- */
-export default class PathsConfiguration {
-  packageJsonAbsoluteFolderPath: string = '';
-}

--- a/src/lib/entities/configuration/modules/i18nextScanner/i18nextScannerModuleConfiguration.ts
+++ b/src/lib/entities/configuration/modules/i18nextScanner/i18nextScannerModuleConfiguration.ts
@@ -2,5 +2,15 @@
  * Configuration for the I18nextJsonToPoConversionModule.
  */
 export default class I18nextScannerModuleConfiguration {
-  enabled: boolean = false;
+  enabled: boolean = true;
+  translationFilesLocation: string = 'src/i18n';
+  codeFileLocations = ['src'];
+  defaultNamespace = 'common';
+  namespaces = ['common'];
+  languages: string[] = ['en'];
+  defaultLanguage: string = 'en';
+  translationFunctionNames: string[] = ['t', 'i18next.t'];
+  translationComponentTranslationKey: string = 'i18nKey';
+  translationComponentName: string = 'Trans';
+  fileExtensions: string[] = ['ts', 'tsx', 'js', 'jsx'];
 }

--- a/src/lib/services/fileChange/fileChangeHandlers/typeScriptFileChangeHandler.test.ts
+++ b/src/lib/services/fileChange/fileChangeHandlers/typeScriptFileChangeHandler.test.ts
@@ -41,6 +41,12 @@ suite('TypeScriptFileChangeHandler', () => {
   });
 
   suite('handleFileChangeAsync', () => {
+    let getConfigStub: sinon.SinonStub;
+
+    teardown(() => {
+      sinon.restore();
+    });
+
     test('should not execute chain if changeFileLocation is undefined', async () => {
       sinon
         .stub(FileContentStore, 'fileChangeContainsTranslationKeys')
@@ -53,6 +59,20 @@ suite('TypeScriptFileChangeHandler', () => {
     });
 
     test('should execute chain if changeFileLocation is provided', async () => {
+      const config = {
+        i18nextScannerModule: {
+          translationFilesLocation: 'locales',
+          translationFunctionNames: ['I18nKey'],
+          translationComponentTranslationKey: 'i18nKey',
+          translationComponentName: 'Trans',
+          codeFileLocations: ['src'],
+        },
+      };
+
+      getConfigStub = sinon
+        .stub(ConfigurationStoreManager.getInstance(), 'getConfig')
+        .returns(config.i18nextScannerModule);
+
       sinon
         .stub(FileContentStore, 'fileChangeContainsTranslationKeys')
         .returns(true);
@@ -90,6 +110,19 @@ suite('TypeScriptFileChangeHandler', () => {
     });
 
     test('should execute chain if changeFileLocation contains translation keys', async () => {
+      const config = {
+        i18nextScannerModule: {
+          translationFilesLocation: 'locales',
+          translationFunctionNames: ['I18nKey'],
+          translationComponentTranslationKey: 'i18nKey',
+          translationComponentName: 'Trans',
+          codeFileLocations: ['src'],
+        },
+      };
+
+      getConfigStub = sinon
+        .stub(ConfigurationStoreManager.getInstance(), 'getConfig')
+        .returns(config.i18nextScannerModule);
       sinon
         .stub(FileContentStore, 'fileChangeContainsTranslationKeys')
         .returns(true);

--- a/src/lib/services/fileChange/fileChangeHandlers/typeScriptFileChangeHandler.test.ts
+++ b/src/lib/services/fileChange/fileChangeHandlers/typeScriptFileChangeHandler.test.ts
@@ -21,12 +21,12 @@ suite('TypeScriptFileChangeHandler', () => {
     readFileSyncStub = sinon.stub(fs, 'readFileSync');
     handler = TypeScriptFileChangeHandler.create();
 
-    const pathsConfiguration = {
-      packageJsonAbsoluteFolderPath: 'some/path',
-    } as GeneralConfiguration['pathsConfiguration'];
-    sinon
-      .stub(ConfigurationStoreManager.getInstance(), 'getConfig')
-      .returns({ pathsConfiguration });
+    // const pathsConfiguration = {
+    //   packageJsonAbsoluteFolderPath: 'some/path',
+    // } as GeneralConfiguration['pathsConfiguration'];
+    // sinon
+    //   .stub(ConfigurationStoreManager.getInstance(), 'getConfig')
+    //   .returns({ pathsConfiguration });
   });
 
   teardown(() => {

--- a/src/lib/services/i18nextScannerService.test.ts
+++ b/src/lib/services/i18nextScannerService.test.ts
@@ -11,10 +11,6 @@ suite('I18nextScannerService', () => {
 
   setup(() => {
     scannerService = I18nextScannerService.getInstance();
-    getConfigStub = sinon.stub(
-      ConfigurationStoreManager.getInstance(),
-      'getConfig'
-    );
   });
 
   teardown(() => {
@@ -31,10 +27,18 @@ suite('I18nextScannerService', () => {
 
   suite('scanCodeAsync', () => {
     test('should scan code for translation keys', async () => {
-      // const pathsConfiguration = {
-      //   packageJsonAbsoluteFolderPath: 'some/path',
-      // } as GeneralConfiguration['pathsConfiguration'];
-      // getConfigStub.returns({ pathsConfiguration });
+      const config = {
+        i18nextScannerModule: {
+          translationFilesLocation: 'locales',
+          translationFunctionNames: ['I18nKey'],
+          translationComponentTranslationKey: 'i18nKey',
+          translationComponentName: 'Trans',
+        },
+      };
+
+      getConfigStub = sinon
+        .stub(ConfigurationStoreManager.getInstance(), 'getConfig')
+        .returns(config.i18nextScannerModule);
 
       const executeScannerStub = (scannerService['executeScanner'] = sinon
         .stub()

--- a/src/lib/services/i18nextScannerService.test.ts
+++ b/src/lib/services/i18nextScannerService.test.ts
@@ -31,10 +31,10 @@ suite('I18nextScannerService', () => {
 
   suite('scanCodeAsync', () => {
     test('should scan code for translation keys', async () => {
-      const pathsConfiguration = {
-        packageJsonAbsoluteFolderPath: 'some/path',
-      } as GeneralConfiguration['pathsConfiguration'];
-      getConfigStub.returns({ pathsConfiguration });
+      // const pathsConfiguration = {
+      //   packageJsonAbsoluteFolderPath: 'some/path',
+      // } as GeneralConfiguration['pathsConfiguration'];
+      // getConfigStub.returns({ pathsConfiguration });
 
       const executeScannerStub = (scannerService['executeScanner'] = sinon
         .stub()

--- a/src/lib/services/i18nextScannerService.ts
+++ b/src/lib/services/i18nextScannerService.ts
@@ -1,44 +1,12 @@
 import * as Sentry from '@sentry/node';
 import sort from 'gulp-sort';
 import I18nextScanner from 'i18next-scanner';
-import path from 'path';
 import vfs from 'vinyl-fs';
 
-import GeneralConfiguration from '../entities/configuration/general/generalConfiguration';
+import I18nextScannerModuleConfiguration from '../entities/configuration/modules/i18nextScanner/i18nextScannerModuleConfiguration';
 import ConfigurationStoreManager from '../stores/configuration/configurationStoreManager';
-
-type I18nextScannerOptions = {
-  compatibilityJSON: string;
-  debug: boolean;
-  removeUnusedKeys: boolean;
-  sort: boolean;
-  func: {
-    list: string[];
-    extensions: string[];
-  };
-  lngs: string[];
-  ns: string[];
-  defaultLng: string;
-  defaultNs: string;
-  defaultValue: string;
-  resource: {
-    loadPath: string;
-    savePath: string;
-    jsonIndent: number;
-    lineEnding: string;
-  };
-  nsSeparator: string;
-  keySeparator: string;
-  pluralSeparator: string;
-  contextSeparator: string;
-  contextDefaultValues: any[];
-  interpolation: {
-    prefix: string;
-    suffix: string;
-  };
-  metadata: any;
-  allowDynamicKeys: boolean;
-};
+import { I18nextScannerOptions } from '../types/i18nextScannerOptions';
+import { getSingleWorkSpaceRoot } from '../utilities/filePathUtilities';
 
 /**
  * Service for scanning code using i18next-scanner.
@@ -70,32 +38,31 @@ export default class I18nextScannerService {
         name: 'TypeScript i18next Scanner Module',
       },
       () => {
-        const packageJsonAbsoluteFolderPath =
-          ConfigurationStoreManager.getInstance().getConfig<GeneralConfiguration>(
-            'general'
-          ).pathsConfiguration.packageJsonAbsoluteFolderPath;
+        const configurationManager = ConfigurationStoreManager.getInstance();
+        const i18nextScannerModuleConfig =
+          configurationManager.getConfig<I18nextScannerModuleConfiguration>(
+            'i18nextScannerModule'
+          );
 
-        const fixedPackageJsonAbsoluteFolderPath = path.normalize(
-          packageJsonAbsoluteFolderPath
-        );
+        const workspaceRoot = getSingleWorkSpaceRoot();
 
         const options: I18nextScannerOptions = {
           compatibilityJSON: 'v3',
-          debug: true,
+          debug: false,
           removeUnusedKeys: true,
           sort: true,
           func: {
-            list: ['I18nKey', 't'],
-            extensions: ['.ts', '.tsx'],
+            list: i18nextScannerModuleConfig.translationFunctionNames,
+            extensions: i18nextScannerModuleConfig.fileExtensions,
           },
-          lngs: ['nl', 'en', 'de', 'pl'],
-          ns: ['common', 'onboarding', 'validation'],
-          defaultLng: 'nl',
-          defaultNs: 'common',
+          lngs: i18nextScannerModuleConfig.languages,
+          ns: i18nextScannerModuleConfig.namespaces,
+          defaultLng: i18nextScannerModuleConfig.defaultLanguage,
+          defaultNs: i18nextScannerModuleConfig.defaultNamespace,
           defaultValue: '',
           resource: {
-            loadPath: `${fixedPackageJsonAbsoluteFolderPath}/public/locales/{{lng}}/{{ns}}.json`,
-            savePath: `${fixedPackageJsonAbsoluteFolderPath}/public/locales/{{lng}}/{{ns}}.json`,
+            loadPath: `${workspaceRoot}/${i18nextScannerModuleConfig.translationFilesLocation}/{{lng}}/{{ns}}.json`,
+            savePath: `${workspaceRoot}/${i18nextScannerModuleConfig.translationFilesLocation}/{{lng}}/{{ns}}.json`,
             jsonIndent: 4,
             lineEnding: 'CRLF',
           },
@@ -109,31 +76,57 @@ export default class I18nextScannerService {
             suffix: '}}',
           },
           metadata: {},
-          allowDynamicKeys: false,
+          allowDynamicKeys: true,
+          trans: {
+            component: i18nextScannerModuleConfig.translationComponentName,
+            i18nKey:
+              i18nextScannerModuleConfig.translationComponentTranslationKey,
+            defaultsKey: 'defaults',
+            extensions: i18nextScannerModuleConfig.fileExtensions,
+            fallbackKey: false,
+
+            // https://react.i18next.com/latest/trans-component#usage-with-simple-html-elements-like-less-than-br-greater-than-and-others-v10.4.0
+            supportBasicHtmlNodes: true, // Enables keeping the name of simple nodes (e.g. <br/>) in translations instead of indexed keys.
+            keepBasicHtmlNodesFor: ['br', 'strong', 'i', 'p'], // Which nodes are allowed to be kept in translations during defaultValue generation of <Trans>.
+
+            // https://github.com/acornjs/acorn/tree/master/acorn#interface
+            acorn: {
+              ecmaVersion: 2020,
+              sourceType: 'module', // defaults to 'module'
+            },
+          },
         };
 
-        this.executeScanner(options, fixedPackageJsonAbsoluteFolderPath);
+        this.executeScanner(
+          options,
+          workspaceRoot,
+          i18nextScannerModuleConfig.codeFileLocations
+        );
       }
     );
   }
 
   private executeScanner = (
     options: I18nextScannerOptions,
-    fixedPackageJsonAbsoluteFolderPath: string
+    workspaceRoot: string,
+    codeFileLocations: string[]
   ) => {
-    vfs
-      .src(
-        [
-          `apps/**/*.{ts,tsx}`,
-          `libs/**/*.{ts,tsx}`,
-          `!apps/**/*.spec.{ts,tsx}`,
-          `!libs/**/*.spec.{ts,tsx}`,
-          `!node_modules/**`,
-        ],
-        { cwd: fixedPackageJsonAbsoluteFolderPath }
-      )
-      .pipe(sort())
-      .pipe(I18nextScanner(options))
-      .pipe(vfs.dest('./'));
+    const scanSources = codeFileLocations.map(
+      location => `${location}/**/*.{ts,tsx}`
+    );
+    scanSources.push(
+      ...codeFileLocations.map(location => `!${location}/**/*.spec.{ts,tsx}`)
+    );
+    scanSources.push('!node_modules/**');
+
+    try {
+      vfs
+        .src(scanSources, { cwd: workspaceRoot })
+        .pipe(sort())
+        .pipe(I18nextScanner(options))
+        .pipe(vfs.dest('./'));
+    } catch (error) {
+      console.error(error);
+    }
   };
 }

--- a/src/lib/services/i18nextScannerService.ts
+++ b/src/lib/services/i18nextScannerService.ts
@@ -29,6 +29,7 @@ export default class I18nextScannerService {
 
   /**
    * Scan code for translation keys in the code file for which the path is provided.
+   * @returns A promise resolving to the scan results.
    */
   public scanCode(): void {
     Sentry.startSpan(
@@ -36,86 +37,82 @@ export default class I18nextScannerService {
         op: 'typeScript.scanCodeFori18next',
         name: 'TypeScript i18next Scanner Module',
       },
-      span => {
-        try {
-          const configManager = ConfigurationStoreManager.getInstance();
-          const config =
-            configManager.getConfig<I18nextScannerModuleConfiguration>(
-              'i18nextScannerModule'
-            );
-          const workspaceRoot = getSingleWorkSpaceRoot();
+      () => {
+        const configurationManager = ConfigurationStoreManager.getInstance();
+        const i18nextScannerModuleConfig =
+          configurationManager.getConfig<I18nextScannerModuleConfiguration>(
+            'i18nextScannerModule'
+          );
 
-          const options: I18nextScannerOptions = {
-            compatibilityJSON: 'v3',
-            debug: false,
-            removeUnusedKeys: true,
-            sort: true,
-            func: {
-              list: config.translationFunctionNames,
-              extensions: config.fileExtensions,
-            },
-            lngs: config.languages,
-            ns: config.namespaces,
-            defaultLng: config.defaultLanguage,
-            defaultNs: config.defaultNamespace,
-            defaultValue: '',
-            resource: {
-              loadPath: `${workspaceRoot}/${config.translationFilesLocation}/{{lng}}/{{ns}}.json`,
-              savePath: `${workspaceRoot}/${config.translationFilesLocation}/{{lng}}/{{ns}}.json`,
-              jsonIndent: 4,
-              lineEnding: 'CRLF',
-            },
-            nsSeparator: ':',
-            keySeparator: '.',
-            pluralSeparator: '_',
-            contextSeparator: ':',
-            contextDefaultValues: [],
-            interpolation: {
-              prefix: '{{',
-              suffix: '}}',
-            },
-            metadata: {},
-            allowDynamicKeys: true,
-            trans: {
-              component: config.translationComponentName,
-              i18nKey: config.translationComponentTranslationKey,
-              defaultsKey: 'defaults',
-              extensions: config.fileExtensions,
-              fallbackKey: false,
-              supportBasicHtmlNodes: true,
-              keepBasicHtmlNodesFor: ['br', 'strong', 'i', 'p'],
-              acorn: {
-                ecmaVersion: 2020,
-                sourceType: 'module',
-              },
-            },
-          };
+        const workspaceRoot = getSingleWorkSpaceRoot();
 
-          const scanSources = [
-            ...config.codeFileLocations.map(
-              location => `${location}/**/*.{ts,tsx}`
-            ),
-            ...config.codeFileLocations.map(
-              location => `!${location}/**/*.spec.{ts,tsx}`
-            ),
-            '!node_modules/**',
-          ];
+        const options: I18nextScannerOptions = {
+          compatibilityJSON: 'v3',
+          debug: false,
+          removeUnusedKeys: true,
+          sort: true,
+          func: {
+            list: i18nextScannerModuleConfig.translationFunctionNames,
+            extensions: i18nextScannerModuleConfig.fileExtensions,
+          },
+          lngs: i18nextScannerModuleConfig.languages,
+          ns: i18nextScannerModuleConfig.namespaces,
+          defaultLng: i18nextScannerModuleConfig.defaultLanguage,
+          defaultNs: i18nextScannerModuleConfig.defaultNamespace,
+          defaultValue: '',
+          resource: {
+            loadPath: `${workspaceRoot}/${i18nextScannerModuleConfig.translationFilesLocation}/{{lng}}/{{ns}}.json`,
+            savePath: `${workspaceRoot}/${i18nextScannerModuleConfig.translationFilesLocation}/{{lng}}/{{ns}}.json`,
+            jsonIndent: 4,
+            lineEnding: 'CRLF',
+          },
+          nsSeparator: ':',
+          keySeparator: '.',
+          pluralSeparator: '_',
+          contextSeparator: ':',
+          contextDefaultValues: [],
+          interpolation: {
+            prefix: '{{',
+            suffix: '}}',
+          },
+          metadata: {},
+          allowDynamicKeys: true,
+          trans: {
+            component: i18nextScannerModuleConfig.translationComponentName,
+            i18nKey:
+              i18nextScannerModuleConfig.translationComponentTranslationKey,
+            defaultsKey: 'defaults',
+            extensions: i18nextScannerModuleConfig.fileExtensions,
+            fallbackKey: false,
+            supportBasicHtmlNodes: true,
+            keepBasicHtmlNodesFor: ['br', 'strong', 'i', 'p'],
+            acorn: {
+              ecmaVersion: 2020,
+              sourceType: 'module', // defaults to 'module'
+            },
+          },
+        };
 
-          this.executeScanner(options, workspaceRoot, scanSources);
-        } catch (error) {
-          console.error(error);
-        } finally {
-          span.end();
-        }
+        const scanSources = i18nextScannerModuleConfig.codeFileLocations.map(
+          location => `${location}/**/*.{ts,tsx}`
+        );
+        scanSources.push(
+          ...i18nextScannerModuleConfig.codeFileLocations.map(
+            location => `!${location}/**/*.spec.{ts,tsx}`
+          )
+        );
+        scanSources.push('!node_modules/**');
+
+        this.executeScanner(options, workspaceRoot, scanSources);
       }
     );
   }
 
-  private executeScanner(
+  private executeScanner = (
     options: I18nextScannerOptions,
     workspaceRoot: string,
     scanSources: string[]
-  ): void {
+  ) => {
     try {
       vfs
         .src(scanSources, { cwd: workspaceRoot })
@@ -125,5 +122,5 @@ export default class I18nextScannerService {
     } catch (error) {
       console.error(error);
     }
-  }
+  };
 }

--- a/src/lib/services/translate/deeplService.ts
+++ b/src/lib/services/translate/deeplService.ts
@@ -56,6 +56,10 @@ export default class DeeplService {
         formality = 'default';
       }
 
+      if (targetLanguage === 'cs') {
+        formality = 'default';
+      }
+
       const result = await DeeplService.translateUsingDeepl(
         DeeplService.translator,
         text,

--- a/src/lib/stores/fileContent/fileContentStore.test.ts
+++ b/src/lib/stores/fileContent/fileContentStore.test.ts
@@ -4,6 +4,7 @@ import sinon from 'sinon';
 import vscode from 'vscode';
 import { window, workspace } from 'vscode';
 
+import ConfigurationStoreManager from '../configuration/configurationStoreManager';
 import FileLocationStore from '../fileLocation/fileLocationStore';
 import FileContentStore from './fileContentStore';
 
@@ -76,7 +77,26 @@ suite('FileContentStore', () => {
   });
 
   suite('fileChangeContainsTranslationKeys', () => {
+    let getConfigStub: sinon.SinonStub;
+
+    teardown(() => {
+      getConfigStub.restore();
+    });
+
     test('should return true if file change contains translation keys', () => {
+      const config = {
+        i18nextScannerModule: {
+          translationFilesLocation: 'locales',
+          translationFunctionNames: ['I18nKey'],
+          translationComponentTranslationKey: 'i18nKey',
+          translationComponentName: 'Trans',
+        },
+      };
+
+      getConfigStub = sinon
+        .stub(ConfigurationStoreManager.getInstance(), 'getConfig')
+        .returns(config.i18nextScannerModule);
+
       const fsPath = '/path/to/file.json';
       const currentFileContents = 'I18nKey("key1")\nI18nKey("key2")\n';
       const previousFileContents = 'I18nKey("key1")\n';

--- a/src/lib/types/i18nextScannerOptions.ts
+++ b/src/lib/types/i18nextScannerOptions.ts
@@ -1,0 +1,45 @@
+export type I18nextScannerOptions = {
+  compatibilityJSON: string;
+  debug: boolean;
+  removeUnusedKeys: boolean;
+  sort: boolean;
+  func: {
+    list: string[];
+    extensions: string[];
+  };
+  lngs: string[];
+  ns: string[];
+  defaultLng: string;
+  defaultNs: string;
+  defaultValue: string;
+  resource: {
+    loadPath: string;
+    savePath: string;
+    jsonIndent: number;
+    lineEnding: string;
+  };
+  nsSeparator: string;
+  keySeparator: string;
+  pluralSeparator: string;
+  contextSeparator: string;
+  contextDefaultValues: any[];
+  interpolation: {
+    prefix: string;
+    suffix: string;
+  };
+  metadata: any;
+  allowDynamicKeys: boolean;
+  trans: {
+    component: string;
+    i18nKey: string;
+    defaultsKey: string;
+    extensions: string[];
+    fallbackKey: boolean;
+    supportBasicHtmlNodes: boolean;
+    keepBasicHtmlNodesFor: string[];
+    acorn: {
+      ecmaVersion: number;
+      sourceType: string;
+    };
+  };
+};

--- a/src/lib/utilities/filePathUtilities.test.ts
+++ b/src/lib/utilities/filePathUtilities.test.ts
@@ -1,6 +1,8 @@
 import assert from 'assert';
+import sinon from 'sinon';
 import vscode from 'vscode';
 
+import ConfigurationStoreManager from '../stores/configuration/configurationStoreManager';
 import {
   determineOutputPath,
   extractFilePathParts,
@@ -9,14 +11,56 @@ import {
 } from './filePathUtilities';
 
 suite('filePathUtilities', () => {
+  let getConfigStub: sinon.SinonStub;
+
+  teardown(() => {
+    sinon.restore();
+  });
+
   suite('extractLocale', () => {
     test('should extract the locale from the file path', () => {
+      const config = {
+        i18nextScannerModule: {
+          translationFilesLocation: 'locales',
+        },
+      };
+
+      getConfigStub = sinon
+        .stub(ConfigurationStoreManager.getInstance(), 'getConfig')
+        .returns(config.i18nextScannerModule);
+
       const filePath = 'C:\\locales\\en\\file.po';
       const locale = extractLocale(filePath);
       assert.equal(locale, 'en');
     });
 
+    test('should extract the locale from the file path with nested translation files location', () => {
+      const config = {
+        i18nextScannerModule: {
+          translationFilesLocation: 'src/i18n',
+        },
+      };
+
+      getConfigStub = sinon
+        .stub(ConfigurationStoreManager.getInstance(), 'getConfig')
+        .returns(config.i18nextScannerModule);
+
+      const filePath = 'C:\\src\\i18n\\en\\file.po';
+      const locale = extractLocale(filePath);
+      assert.equal(locale, 'en');
+    });
+
     test('should throw an error for invalid file path format', () => {
+      const config = {
+        i18nextScannerModule: {
+          translationFilesLocation: 'src/i18n',
+        },
+      };
+
+      getConfigStub = sinon
+        .stub(ConfigurationStoreManager.getInstance(), 'getConfig')
+        .returns(config.i18nextScannerModule);
+
       const filePath = 'C:\\invalid\\file.path';
       assert.throws(() => extractLocale(filePath), {
         message: 'Invalid file path format',
@@ -56,12 +100,42 @@ suite('filePathUtilities', () => {
 
   suite('extractFilePathParts', () => {
     test('should extract the locale and output path from the file path', () => {
+      const config = {
+        i18nextScannerModule: {
+          translationFilesLocation: 'locales',
+        },
+      };
+
+      getConfigStub = sinon
+        .stub(ConfigurationStoreManager.getInstance(), 'getConfig')
+        .returns(config.i18nextScannerModule);
+
       const filePath = 'C:\\locales\\en\\file.po';
       const filePathParts = extractFilePathParts(filePath);
 
       assert.deepStrictEqual(filePathParts, {
         locale: 'en',
         outputPath: vscode.Uri.file('C:\\locales\\en\\file.json'),
+      });
+    });
+
+    test('should extract the locale and output path from the file path with nested translation files location', () => {
+      const config = {
+        i18nextScannerModule: {
+          translationFilesLocation: 'src/i18n',
+        },
+      };
+
+      getConfigStub = sinon
+        .stub(ConfigurationStoreManager.getInstance(), 'getConfig')
+        .returns(config.i18nextScannerModule);
+
+      const filePath = 'C:\\src\\i18n\\en\\file.po';
+      const filePathParts = extractFilePathParts(filePath);
+
+      assert.deepStrictEqual(filePathParts, {
+        locale: 'en',
+        outputPath: vscode.Uri.file('C:\\src\\i18n\\en\\file.json'),
       });
     });
   });

--- a/src/lib/utilities/filePathUtilities.ts
+++ b/src/lib/utilities/filePathUtilities.ts
@@ -7,6 +7,10 @@ import ConfigurationStoreManager from '../stores/configuration/configurationStor
 import { ExtractedFileParts as FilePathParts } from '../types/extractedFileParts';
 
 export function extractLocale(filePath: string): string {
+  let test =
+    ConfigurationStoreManager.getInstance().getConfig<I18nextScannerModuleConfiguration>(
+      'i18nextScannerModule'
+    ).translationFilesLocation;
   const translationFilesLocation =
     ConfigurationStoreManager.getInstance()
       .getConfig<I18nextScannerModuleConfiguration>('i18nextScannerModule')

--- a/src/lib/utilities/filePathUtilities.ts
+++ b/src/lib/utilities/filePathUtilities.ts
@@ -1,11 +1,22 @@
 import path from 'path';
-import vscode from 'vscode';
+import vscode, { workspace } from 'vscode';
 import { Uri } from 'vscode';
 
+import I18nextScannerModuleConfiguration from '../entities/configuration/modules/i18nextScanner/i18nextScannerModuleConfiguration';
+import ConfigurationStoreManager from '../stores/configuration/configurationStoreManager';
 import { ExtractedFileParts as FilePathParts } from '../types/extractedFileParts';
 
 export function extractLocale(filePath: string): string {
-  const localePattern = /\\locales\\([^\\]+)\\/;
+  const translationFilesLocation =
+    ConfigurationStoreManager.getInstance()
+      .getConfig<I18nextScannerModuleConfiguration>('i18nextScannerModule')
+      .translationFilesLocation.split('/')
+      .pop() || '';
+
+  const localePattern = new RegExp(
+    `\\\\${translationFilesLocation}\\\\([^\\\\]+)\\\\`
+  );
+
   const match = localePattern.exec(filePath);
   if (!match || match.length < 2) {
     throw new Error('Invalid file path format');
@@ -45,4 +56,16 @@ export function extractFilePathParts(filePath: string): FilePathParts {
  */
 export function getFileExtension(uri: vscode.Uri): string {
   return path.extname(uri.fsPath).slice(1);
+}
+
+export function getSingleWorkSpaceRoot(): string {
+  const workspaceFolders = workspace.workspaceFolders;
+  if (!workspaceFolders) {
+    throw new Error('No workspace folders found');
+  }
+
+  // Assuming you want to use the first workspace folder
+  const rootFolder = workspaceFolders[0].uri.fsPath;
+
+  return rootFolder;
 }


### PR DESCRIPTION
Your localization experience just got a major upgrade!
We've streamlined the configuration process by removing
redundant paths configuration. We've also enabled dynamic
keys and improved parsing capabilities for <Trans> component,
handling basic HTML nodes smoothly. 

Say goodbye to tedious setup and hello to seamless
i18n integration and broader language support!

Happy translating with less hassle!