### PR TITLE
ci: add pre-release publish step and improve artifact upload

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,11 +43,17 @@ jobs:
         if: ${{ steps.release.outputs.release_created }}
         run: npx vsce package -o i18nWeave-vscode-${{steps.release.outputs.tag_name}}.vsix --pre-release
 
-      - name: Upload Release Artifact
+      - name: Upload Release Artifact to GitHub
         if: ${{ steps.release.outputs.release_created }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: gh release upload ${{steps.release.outputs.tag_name}} i18nWeave-vscode-${{steps.release.outputs.tag_name}}.vsix
+
+      - name: Release Pre-release extension
+        if: ${{ steps.release.outputs.release_created }}
+        run: npx vsce publish --packagePath i18nWeave-vscode-${{steps.release.outputs.tag_name}}.vsix --pre-release
+        env:
+          VSCE_PAT: ${{ secrets.VSCE_PAT }}
 
       - name: Attest Build Provenance
         if: ${{ steps.release.outputs.release_created }}


### PR DESCRIPTION
Modify release workflow to include a step to publish the package
as a pre-release extension using 'vsce'. Also, update the step 
name for uploading the release artifact to GitHub for clarity.