### PR TITLE
fix: update repository URL in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "license": "SEE LICENSE IN LICENSE.txt",
   "repository": {
     "type": "git",
-    "url": "https://github.com/qvotaxon/translation-file-watcher"
+    "url": "https://github.com/qvotaxon/i18nWeave-vscode"
   },
   "version": "0.4.1",
   "engines": {


### PR DESCRIPTION
Change repository URL to reflect the new project name. This ensures 
the metadata correctly directs to the current repository location.