### PR TITLE
fix: enable preRelease and update download badge URL

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,6 +58,7 @@ jobs:
       - name: Publish VS Code Extension
         uses: HaaLeo/publish-vscode-extension@v1.6.2
         with:
+          preRelease: true
           pat: ${{ secrets.VSCE_PAT }}
           registryUrl: https://marketplace.visualstudio.com
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![Downloads](https://img.shields.io/visual-studio-marketplace/d/qvotaxon.i18nweave-vscode?logo=github&branch=main)
+![Downloads](https://img.shields.io/visual-studio-marketplace/d/qvotaxon.i18nweave?logo=github&branch=main)
 ![Latest version](https://img.shields.io/github/package-json/v/qvotaxon/i18nweave-vscode)
 
 [![Build](https://github.com/qvotaxon/i18nWeave-vscode/actions/workflows/build.yml/badge.svg?branch=main)](https://github.com/qvotaxon/i18nWeave-vscode/actions/workflows/build.yml)


### PR DESCRIPTION
Add preRelease flag in release workflow to publish pre-release
versions. Update download badge URL in README.md to reflect the
correct extension identifier.