### PR TITLE
fix: conditionally run VS Code extension publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,11 +56,12 @@ jobs:
       #     VSCE_PAT: ${{ secrets.VSCE_PAT }}
 
       - name: Publish VS Code Extension
+        if: ${{ steps.release.outputs.release_created }}
         uses: HaaLeo/publish-vscode-extension@v1.6.2
         with:
-          preRelease: true
           pat: ${{ secrets.VSCE_PAT }}
           registryUrl: https://marketplace.visualstudio.com
+          preRelease: true
 
       - name: Attest Build Provenance
         if: ${{ steps.release.outputs.release_created }}


### PR DESCRIPTION
Update the GitHub Actions workflow to conditionally run the 
'Publish VS Code Extension' step based on the release creation 
status. This ensures the step is only executed if a new release 
has been successfully created, improving the efficiency and 
reliability of the release process.