### PR TITLE
fix: remove commented pre-release extension steps

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,12 +49,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: gh release upload ${{steps.release.outputs.tag_name}} i18nWeave-vscode-${{steps.release.outputs.tag_name}}.vsix
 
-      # - name: Release Pre-release extension
-      #   if: ${{ steps.release.outputs.release_created }}
-      #   run: npx vsce publish --packagePath i18nWeave-vscode-${{steps.release.outputs.tag_name}}.vsix --pre-release
-      #   env:
-      #     VSCE_PAT: ${{ secrets.VSCE_PAT }}
-
       - name: Publish VS Code Extension
         if: ${{ steps.release.outputs.release_created }}
         uses: HaaLeo/publish-vscode-extension@v1.6.2


### PR DESCRIPTION
Remove unused and commented out steps for pre-releasing the VS Code
extension in the release workflow. This cleanup ensures the
workflow file is more readable and maintains only necessary actions.