### PR TITLE
chore: update .vscodeignore

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -9,3 +9,4 @@ vsc-extension-quickstart.md
 **/*.map
 **/*.ts
 **/.vscode-test.*
+.sentryclirc


### PR DESCRIPTION
Add .sentryclirc to .vscodeignore to exclude it from version control.
This ensures sensitive configuration details are not included in the
repository, enhancing security and privacy.