### PR TITLE
ci(sentry): add Sentry release step to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,6 +67,15 @@ jobs:
           registryUrl: https://marketplace.visualstudio.com
           preRelease: true
 
+      - name: Create Sentry release
+        uses: getsentry/action-release@v1
+        env:
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          SENTRY_ORG: i18nweave
+          SENTRY_PROJECT: i18nweave-vscode
+        with:
+          version: ${{ steps.release.outputs.tag_name }}
+
       - name: Attest Build Provenance
         if: ${{ steps.release.outputs.release_created }}
         uses: actions/attest-build-provenance@v1.3.1


### PR DESCRIPTION
Add a step to create a Sentry release in the GitHub Actions workflow. This enables better tracking and monitoring of releases via Sentry. Ensure continuity by retaining existing steps and configurations.