### PR TITLE
ci(release.yml): add condition to create Sentry release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,6 +68,7 @@ jobs:
           preRelease: true
 
       - name: Create Sentry release
+        if: ${{ steps.release.outputs.release_created }}
         uses: getsentry/action-release@v1
         env:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}


### PR DESCRIPTION
Add a condition to the Sentry release step to ensure it only runs if the release was successfully created, preventing unnecessary executions and potential errors. This improves workflow efficiency.