### PR TITLE
fix(file-change-handler): improve robustness checking files

### DIFF
--- a/src/lib/services/fileChange/fileChangeHandlers/codeFileChangeHandler.test.ts
+++ b/src/lib/services/fileChange/fileChangeHandlers/codeFileChangeHandler.test.ts
@@ -1,10 +1,10 @@
 import assert from 'assert';
+import fs from 'fs';
 import sinon from 'sinon';
 import vscode, { Uri } from 'vscode';
 
 import { ChainType } from '../../../enums/chainType';
 import ModuleContext from '../../../interfaces/moduleContext';
-import ModuleChainManager from '../../../modules/moduleChainManager';
 import CodeTranslationStore from '../../../stores/codeTranslation/codeTranslationStore';
 import CodeFileChangeHandler from './codeFileChangeHandler';
 
@@ -33,12 +33,6 @@ suite('CodeFileChangeHandler', () => {
         (CodeFileChangeHandler.moduleChainManager.executeChainAsync =
           sinon.stub());
 
-      // const moduleChainManagerStub =
-      //   sinon.createStubInstance(ModuleChainManager);
-
-      // const executeChainStub = (moduleChainManagerStub.executeChainAsync =
-      //   sinon.stub());
-
       await handler.handleFileChangeAsync();
 
       sinon.assert.notCalled(executeChainAsyncStub);
@@ -50,6 +44,7 @@ suite('CodeFileChangeHandler', () => {
         (CodeFileChangeHandler.moduleChainManager.executeChainAsync =
           sinon.stub());
 
+      sinon.stub(fs, 'existsSync').returns(true);
       sinon
         .stub(
           CodeTranslationStore.getInstance(),
@@ -138,6 +133,7 @@ suite('CodeFileChangeHandler', () => {
         .returns(Promise.resolve(true));
 
       const uri = vscode.Uri.file('path/to/file.ts');
+      sinon.stub(fs, 'existsSync').returns(true);
 
       await handler.handleFileChangeAsync(uri);
 

--- a/src/lib/services/fileChange/fileChangeHandlers/codeFileChangeHandler.ts
+++ b/src/lib/services/fileChange/fileChangeHandlers/codeFileChangeHandler.ts
@@ -1,4 +1,5 @@
 import * as Sentry from '@sentry/node';
+import fs from 'fs';
 import { Uri } from 'vscode';
 
 import { ChainType } from '../../../enums/chainType';
@@ -46,10 +47,14 @@ export default class CodeFileChangeHandler extends FileChangeHandler {
           return;
         }
 
-        const hasTranslationFunctions =
-          await CodeTranslationStore.getInstance().fileChangeContainsTranslationFunctionsAsync(
-            changeFileLocation.fsPath
-          );
+        let hasTranslationFunctions = false;
+
+        if (fs.existsSync(changeFileLocation.fsPath)) {
+          hasTranslationFunctions =
+            await CodeTranslationStore.getInstance().fileChangeContainsTranslationFunctionsAsync(
+              changeFileLocation.fsPath
+            );
+        }
 
         if (!isFileDeletionChange && !hasTranslationFunctions) {
           return;


### PR DESCRIPTION
Fixes an issue where deleted files would not always trigger the code scanning logic to be triggered. Now you can safely assume your translations will be cleaned up automatically.