### PR TITLE
fix(config-wizard): persist configuration after wizard completion

### DIFF
--- a/src/lib/stores/configuration/configurationStore.ts
+++ b/src/lib/stores/configuration/configurationStore.ts
@@ -16,19 +16,25 @@ export default class ConfigurationStore {
   }
 
   async setAsync<K extends keyof ExtensionConfiguration>(
-    key: K,
-    value: ExtensionConfiguration[K],
+    moduleName: K,
+    moduleValue: ExtensionConfiguration[K],
     configurationTarget = ConfigurationTarget.Workspace
   ): Promise<void> {
-    Object.keys(value).forEach(key => {
+    Object.keys(moduleValue).forEach(async configurationKey => {
       const configuration = vscode.workspace.getConfiguration(
-        `i18nWeave.${key}`
+        `i18nWeave.${moduleName}`
       );
-      const configValue = (value as { [key: string]: any })[key];
-      configuration.update(key, configValue, configurationTarget);
+      const configurationValue = (moduleValue as { [key: string]: any })[
+        configurationKey
+      ];
+      await configuration.update(
+        configurationKey,
+        configurationValue,
+        configurationTarget
+      );
     });
 
-    this.options[key] = value;
+    this.options[moduleName] = moduleValue;
   }
 
   update(userOptions: Partial<ExtensionConfiguration>): void {

--- a/src/lib/utilities/filePathUtilities.ts
+++ b/src/lib/utilities/filePathUtilities.ts
@@ -140,11 +140,16 @@ export function getPosixPathFromUri(fsPath: string): string {
  * @returns The sanitized array of file locations.
  */
 export function sanitizeLocations(locations: string[]): string[] {
-  return locations.map(location => {
+  const sanitizedLocations: string[] = [];
+
+  locations.forEach(location => {
     location = location.endsWith('/')
       ? location.substring(location.length)
       : location;
     location = location.startsWith('/') ? location.substring(1) : location;
-    return location;
+
+    sanitizedLocations.push(location);
   });
+
+  return sanitizedLocations;
 }

--- a/src/lib/utilities/windowUtilities.ts
+++ b/src/lib/utilities/windowUtilities.ts
@@ -12,7 +12,13 @@ import { getPosixPathFromUri, getProjectRootFolder } from './filePathUtilities';
 export async function promptForFolderAsync(
   placeHolder: string
 ): Promise<string | undefined> {
-  return (await showOpenDialog(placeHolder)) as string;
+  const selectedFolder = await showOpenDialog(placeHolder);
+
+  if (!selectedFolder) {
+    return undefined;
+  }
+
+  return selectedFolder[0];
 }
 
 /**
@@ -36,7 +42,7 @@ export async function promptForFoldersAsync(
 export async function showOpenDialog(
   placeHolder: string,
   canSelectMany = false
-): Promise<string | string[] | undefined> {
+): Promise<string[] | undefined> {
   const folderSelectionPrompt = await vscode.window.showQuickPick(
     [placeHolder],
     {
@@ -64,7 +70,7 @@ export async function showOpenDialog(
     return folderUri.map(folderUri => getRelativePath(folderUri.fsPath));
   }
 
-  return getRelativePath(folderUri[0].fsPath);
+  return [getRelativePath(folderUri[0].fsPath)];
 }
 
 function getRelativePath(folderPath: string) {


### PR DESCRIPTION
A bug has been fixed where in some cases the configuration wizard would not persist the set configuration. This would cause i18nWeave to only work correctly during the same run where the wizard had been ran. 

This issue has now been resolved, ensuring a continuous workflow, including after restarts of VsCode.

Happy weaving! 🌍