### PR TITLE
refactor: relocate i18nextScannerService to a new directory

### DIFF
--- a/src/lib/modules/i18nextScanner/i18nextScannerModule.test.ts
+++ b/src/lib/modules/i18nextScanner/i18nextScannerModule.test.ts
@@ -1,6 +1,6 @@
 import sinon from 'sinon';
 
-import I18nextScannerService from '../../services/i18nextScannerService';
+import I18nextScannerService from '../../services/configurationWizard/i18nextScannerService';
 import I18nextScannerModule from './i18nextScannerModule';
 import I18nextScannerModuleContext from './i18nextScannerModuleContext';
 

--- a/src/lib/modules/i18nextScanner/i18nextScannerModule.test.ts
+++ b/src/lib/modules/i18nextScanner/i18nextScannerModule.test.ts
@@ -1,6 +1,6 @@
 import sinon from 'sinon';
 
-import I18nextScannerService from '../../services/configurationWizard/i18nextScannerService';
+import I18nextScannerService from '../../services/i18nextScannerService/i18nextScannerService';
 import I18nextScannerModule from './i18nextScannerModule';
 import I18nextScannerModuleContext from './i18nextScannerModuleContext';
 

--- a/src/lib/modules/i18nextScanner/i18nextScannerModule.ts
+++ b/src/lib/modules/i18nextScanner/i18nextScannerModule.ts
@@ -1,6 +1,6 @@
 import * as Sentry from '@sentry/node';
 
-import I18nextScannerService from '../../services/i18nextScannerService';
+import I18nextScannerService from '../../services/configurationWizard/i18nextScannerService';
 import { BaseActionModule } from '../baseActionModule';
 import I18nextScannerModuleContext from './i18nextScannerModuleContext';
 

--- a/src/lib/modules/i18nextScanner/i18nextScannerModule.ts
+++ b/src/lib/modules/i18nextScanner/i18nextScannerModule.ts
@@ -1,6 +1,6 @@
 import * as Sentry from '@sentry/node';
 
-import I18nextScannerService from '../../services/configurationWizard/i18nextScannerService';
+import I18nextScannerService from '../../services/i18nextScannerService/i18nextScannerService';
 import { BaseActionModule } from '../baseActionModule';
 import I18nextScannerModuleContext from './i18nextScannerModuleContext';
 

--- a/src/lib/services/i18nextScannerService/i18nextScannerService.test.ts
+++ b/src/lib/services/i18nextScannerService/i18nextScannerService.test.ts
@@ -1,9 +1,9 @@
 import * as assert from 'assert';
 import sinon from 'sinon';
 
-import GeneralConfiguration from '../entities/configuration/general/generalConfiguration';
-import I18nextScannerModuleConfiguration from '../entities/configuration/modules/i18nextScanner/i18nextScannerModuleConfiguration';
-import ConfigurationStoreManager from '../stores/configuration/configurationStoreManager';
+import GeneralConfiguration from '../../entities/configuration/general/generalConfiguration';
+import I18nextScannerModuleConfiguration from '../../entities/configuration/modules/i18nextScanner/i18nextScannerModuleConfiguration';
+import ConfigurationStoreManager from '../../stores/configuration/configurationStoreManager';
 import I18nextScannerService from './i18nextScannerService';
 
 suite('I18nextScannerService', () => {

--- a/src/lib/services/i18nextScannerService/i18nextScannerService.ts
+++ b/src/lib/services/i18nextScannerService/i18nextScannerService.ts
@@ -3,10 +3,10 @@ import sort from 'gulp-sort';
 import I18nextScanner from 'i18next-scanner';
 import vfs from 'vinyl-fs';
 
-import I18nextScannerModuleConfiguration from '../entities/configuration/modules/i18nextScanner/i18nextScannerModuleConfiguration';
-import ConfigurationStoreManager from '../stores/configuration/configurationStoreManager';
-import { I18nextScannerOptions } from '../types/i18nextScannerOptions';
-import { getProjectRootFolder } from '../utilities/filePathUtilities';
+import I18nextScannerModuleConfiguration from '../../entities/configuration/modules/i18nextScanner/i18nextScannerModuleConfiguration';
+import ConfigurationStoreManager from '../../stores/configuration/configurationStoreManager';
+import { I18nextScannerOptions } from '../../types/i18nextScannerOptions';
+import { getProjectRootFolder } from '../../utilities/filePathUtilities';
 
 /**
  * Service for scanning code using i18next-scanner.

--- a/src/lib/stores/configuration/configurationStore.ts
+++ b/src/lib/stores/configuration/configurationStore.ts
@@ -16,19 +16,25 @@ export default class ConfigurationStore {
   }
 
   async setAsync<K extends keyof ExtensionConfiguration>(
-    key: K,
-    value: ExtensionConfiguration[K],
+    moduleName: K,
+    moduleValue: ExtensionConfiguration[K],
     configurationTarget = ConfigurationTarget.Workspace
   ): Promise<void> {
-    Object.keys(value).forEach(key => {
+    Object.keys(moduleValue).forEach(async configurationKey => {
       const configuration = vscode.workspace.getConfiguration(
-        `i18nWeave.${key}`
+        `i18nWeave.${moduleName}`
       );
-      const configValue = (value as { [key: string]: any })[key];
-      configuration.update(key, configValue, configurationTarget);
+      const configurationValue = (moduleValue as { [key: string]: any })[
+        configurationKey
+      ];
+      await configuration.update(
+        configurationKey,
+        configurationValue,
+        configurationTarget
+      );
     });
 
-    this.options[key] = value;
+    this.options[moduleName] = moduleValue;
   }
 
   update(userOptions: Partial<ExtensionConfiguration>): void {

--- a/src/lib/utilities/filePathUtilities.ts
+++ b/src/lib/utilities/filePathUtilities.ts
@@ -140,11 +140,16 @@ export function getPosixPathFromUri(fsPath: string): string {
  * @returns The sanitized array of file locations.
  */
 export function sanitizeLocations(locations: string[]): string[] {
-  return locations.map(location => {
+  const sanitizedLocations: string[] = [];
+
+  locations.forEach(location => {
     location = location.endsWith('/')
       ? location.substring(location.length)
       : location;
     location = location.startsWith('/') ? location.substring(1) : location;
-    return location;
+
+    sanitizedLocations.push(location);
   });
+
+  return sanitizedLocations;
 }

--- a/src/lib/utilities/windowUtilities.test.ts
+++ b/src/lib/utilities/windowUtilities.test.ts
@@ -39,7 +39,7 @@ suite('WindowUtilities', () => {
 
     const result = await windowUtilities.showOpenDialog('Select Folder');
 
-    assert.strictEqual(result, ['/path/to/folder']);
+    assert.deepEqual(result, ['/path/to/folder']);
   });
 
   test('showOpenDialog should return an array of folderUri.fsPath if folderUri has length greater than 1', async () => {

--- a/src/lib/utilities/windowUtilities.test.ts
+++ b/src/lib/utilities/windowUtilities.test.ts
@@ -32,14 +32,14 @@ suite('WindowUtilities', () => {
     assert.strictEqual(result, undefined);
   });
 
-  test('showOpenDialog should return folderUri[0].fsPath if folderUri has length of 1', async () => {
+  test('showOpenDialog should return and array with length one if only a single folder was picked', async () => {
     const folderUri = [vscode.Uri.file('/path/to/folder')];
     sandbox.stub(vscode.window, 'showQuickPick').resolves({} as any);
     sandbox.stub(vscode.window, 'showOpenDialog').resolves(folderUri);
 
     const result = await windowUtilities.showOpenDialog('Select Folder');
 
-    assert.strictEqual(result, '/path/to/folder');
+    assert.strictEqual(result, ['/path/to/folder']);
   });
 
   test('showOpenDialog should return an array of folderUri.fsPath if folderUri has length greater than 1', async () => {

--- a/src/lib/utilities/windowUtilities.ts
+++ b/src/lib/utilities/windowUtilities.ts
@@ -12,7 +12,13 @@ import { getPosixPathFromUri, getProjectRootFolder } from './filePathUtilities';
 export async function promptForFolderAsync(
   placeHolder: string
 ): Promise<string | undefined> {
-  return (await showOpenDialog(placeHolder)) as string;
+  const selectedFolder = await showOpenDialog(placeHolder);
+
+  if (!selectedFolder) {
+    return undefined;
+  }
+
+  return selectedFolder[0];
 }
 
 /**
@@ -36,7 +42,7 @@ export async function promptForFoldersAsync(
 export async function showOpenDialog(
   placeHolder: string,
   canSelectMany = false
-): Promise<string | string[] | undefined> {
+): Promise<string[] | undefined> {
   const folderSelectionPrompt = await vscode.window.showQuickPick(
     [placeHolder],
     {
@@ -64,7 +70,7 @@ export async function showOpenDialog(
     return folderUri.map(folderUri => getRelativePath(folderUri.fsPath));
   }
 
-  return getRelativePath(folderUri[0].fsPath);
+  return [getRelativePath(folderUri[0].fsPath)];
 }
 
 function getRelativePath(folderPath: string) {


### PR DESCRIPTION
Move i18nextScannerService.ts to i18nextScannerService directory for 
better module organization. This enhances maintainability by aligning 
with our file structure conventions and improves code navigation.