### PR TITLE
fix: temporarily disable PO to JSON conversion

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,16 +32,10 @@ i18nWeave is a Visual Studio Code extension designed to streamline the managemen
 
 - **Installation Wizard**: Get up and running in no time using the build-in configuration wizard. Pick any of the build-in framework configurations and get started in just a few clicks. Or with just a few more clicks setup a custom project using i18next translations.
 - **Translation Key Extraction**: This feature allows for the easy extraction of translation keys from code files, which ensures the accurate localization of your application.
-- **PO File Support**: You have the option to use PO files for managing translations. This feature enables seamless integration with your existing localization workflows.
-- **PO to i18n-next JSON Conversion**: Effortlessly convert PO files into the i18n-next JSON format and vice versa. This conversion facilitates compatibility with a variety of localization tools and libraries.
 - **Automatic Translations**: When you add a translation for one locale, translations for all other locales are automatically generated. The following translators have been (or will be) implemented:
   - [DeepL](https://www.deepl.com/translator) (requires an Api key)
   - [Google Translate](https://translate.google.com) (not implemented yet)
-
-<!-- ### Modes
-
-- **Manual Mode**: Take control of translation key extraction by manually clicking on status bar icons, allowing for precise management of translation files.
-- **Automatic Mode**: Enable automatic translation key extraction upon file save, ensuring real-time updates and effortless synchronization of translation files with your codebase. -->
+- **PO File Support**: Temporarily disabled.
 
 <!-- ## Installation
 
@@ -66,6 +60,11 @@ TODO
 - show code samples and required configuration -->
 
 ## 🚧 Roadmap
+
+### (Temporarily disabled)
+
+- **PO File Support**: You have the option to use PO files for managing translations. This feature enables seamless integration with your existing localization workflows.
+- **PO to i18n-next JSON Conversion**: Effortlessly convert PO files into the i18n-next JSON format and vice versa. This conversion facilitates compatibility with a variety of localization tools and libraries.
 
 ### Somewhere in the nearer future
 

--- a/package.json
+++ b/package.json
@@ -105,7 +105,7 @@
       },
       {
         "id": "i18nextJsonToPoConversionModule",
-        "title": "i18next Json To Po Conversion Module",
+        "title": "(Temporarily Disabled) --- i18next Json To Po Conversion Module",
         "properties": {
           "i18nWeave.i18nextJsonToPoConversionModule.enabled": {
             "type": "boolean",

--- a/src/lib/modules/i18nextJsonToPoConversion/i18nextJsonToPoConversionModule.test.ts
+++ b/src/lib/modules/i18nextJsonToPoConversion/i18nextJsonToPoConversionModule.test.ts
@@ -48,6 +48,9 @@ suite('I18nextJsonToPoConversionModule Tests', () => {
       locale,
     };
 
+    // @ts-ignore - temporarilyDisabled is private
+    module.temporarilyDisabled = false;
+
     await module.executeAsync(context);
 
     let expectedOutput = i18next2po(locale, jsonContent, {
@@ -70,6 +73,9 @@ suite('I18nextJsonToPoConversionModule Tests', () => {
       jsonContent,
       locale,
     };
+
+    // @ts-ignore - temporarilyDisabled is private
+    module.temporarilyDisabled = false;
 
     await module.executeAsync(context);
 
@@ -104,6 +110,9 @@ suite('I18nextJsonToPoConversionModule Tests', () => {
       jsonContent: null,
       locale,
     };
+
+    // @ts-ignore - temporarilyDisabled is private
+    module.temporarilyDisabled = false;
 
     await module.executeAsync(context);
 

--- a/src/lib/modules/i18nextJsonToPoConversion/i18nextJsonToPoConversionModule.ts
+++ b/src/lib/modules/i18nextJsonToPoConversion/i18nextJsonToPoConversionModule.ts
@@ -11,6 +11,8 @@ import I18nextJsonToPoConversionModuleContext from './i18nextJsonToPoConversionM
  * Module for converting JSON to PO using i18next library.
  */
 export default class I18nextJsonToPoConversionModule extends BaseActionModule {
+  private temporarilyDisabled = true;
+
   /**
    * Executes the conversion of JSON to PO.
    * @param context - The context for the conversion.
@@ -20,6 +22,7 @@ export default class I18nextJsonToPoConversionModule extends BaseActionModule {
     context: I18nextJsonToPoConversionModuleContext
   ): Promise<void> {
     if (
+      !this.temporarilyDisabled &&
       ConfigurationStoreManager.getInstance().getConfig<I18nextJsonToPoConversionModuleConfiguration>(
         'i18nextJsonToPoConversionModule'
       ).enabled

--- a/src/lib/modules/poToI18nextJsonConversion/poToI18nextJsonConversionModule.test.ts
+++ b/src/lib/modules/poToI18nextJsonConversion/poToI18nextJsonConversionModule.test.ts
@@ -62,6 +62,9 @@ msgstr "${Date.now().toString()}"`;
       locale,
     };
 
+    // @ts-ignore - temporarilyDisabled is private
+    module.temporarilyDisabled = false;
+
     await module.executeAsync(context);
 
     let outputFileContent = await FileReader.readFileAsync(outputPath.fsPath);
@@ -86,6 +89,9 @@ msgstr "${Date.now().toString()}"`;
       poContent: null,
       locale,
     };
+
+    // @ts-ignore - temporarilyDisabled is private
+    module.temporarilyDisabled = false;
 
     await module.executeAsync(context);
 

--- a/src/lib/modules/poToI18nextJsonConversion/poToI18nextJsonConversionModule.ts
+++ b/src/lib/modules/poToI18nextJsonConversion/poToI18nextJsonConversionModule.ts
@@ -12,6 +12,8 @@ import PoToI18nextJsonConversionModuleContext from './poToI18nextJsonConversionM
  * Module for converting PO to JSON using i18next library.
  */
 export default class PoToI18nextJsonConversionModule extends BaseActionModule {
+  private temporarilyDisabled = true;
+
   /**
    * Executes the conversion of PO to JSON.
    * @param context - The context for the conversion.
@@ -21,6 +23,7 @@ export default class PoToI18nextJsonConversionModule extends BaseActionModule {
     context: PoToI18nextJsonConversionModuleContext
   ): Promise<void> {
     if (
+      !this.temporarilyDisabled &&
       ConfigurationStoreManager.getInstance().getConfig<I18nextJsonToPoConversionModuleConfiguration>(
         'i18nextJsonToPoConversionModule'
       ).enabled

--- a/src/lib/services/fileChange/fileChangeHandlers/jsonFileChangeHandler.test.ts
+++ b/src/lib/services/fileChange/fileChangeHandlers/jsonFileChangeHandler.test.ts
@@ -34,6 +34,7 @@ suite('JsonFileChangeHandler', () => {
             nextModule: {
               extensionContext: {},
               nextModule: null,
+              temporarilyDisabled: true,
             },
           },
         },

--- a/src/lib/services/fileChange/fileChangeHandlers/poFileChangeHandler.test.ts
+++ b/src/lib/services/fileChange/fileChangeHandlers/poFileChangeHandler.test.ts
@@ -30,6 +30,7 @@ suite('PoFileChangeHandler', () => {
           nextModule: {
             extensionContext: {},
             nextModule: null,
+            temporarilyDisabled: true,
           },
         },
       },


### PR DESCRIPTION
We're temporarily disabling the PO to i18next JSON and JSON to PO
conversion modules to focus on enhancing other features. This means
you won't be able to use these specific conversions right now. Thanks
for your patience as we make i18nWeave even better! Check back soon
for updates.