### PR TITLE
fix: Clarify Status of i18next Module Option

### DIFF
--- a/package.json
+++ b/package.json
@@ -105,12 +105,12 @@
       },
       {
         "id": "i18nextJsonToPoConversionModule",
-        "title": "(Temporarily Disabled) --- i18next Json To Po Conversion Module",
+        "title": "i18next Json To Po Conversion Module",
         "properties": {
           "i18nWeave.i18nextJsonToPoConversionModule.enabled": {
             "type": "boolean",
             "default": "",
-            "description": "Enable the i18next Json To Po Conversion module."
+            "description": "(Temporarily Disabled) --- Enable the i18next Json To Po Conversion module."
           }
         }
       },


### PR DESCRIPTION
Improve the clarity around the i18next Json To Po Conversion module
by adjusting the title and description. We highlight its temporary
disabled status to keep you informed and prevent any confusion.
Happy coding!