### PR TITLE
fix: correct handling of single file extension

### DIFF
--- a/src/libs/feature/feature-i18next-scanner-service/src/lib/i18next-scanner-service.ts
+++ b/src/libs/feature/feature-i18next-scanner-service/src/lib/i18next-scanner-service.ts
@@ -93,15 +93,22 @@ export class I18nextScannerService {
       },
     };
 
+    const fileExtensions = config.fileExtensions;
+    const hasMultipleExtensions = fileExtensions.length > 1;
+
+    const extensionPattern = hasMultipleExtensions
+      ? `{${fileExtensions.join(',')}}`
+      : fileExtensions[0];
+
     const scanSources = [
-      ...config.codeFileLocations.map(
-        location =>
-          `${location.replace(/^\//, '')}/**/*.{${config.fileExtensions}}`
-      ),
-      ...config.codeFileLocations.map(
-        location =>
-          `!${location.replace(/^\//, '')}/**/*.spec.{${config.fileExtensions}}`
-      ),
+      ...config.codeFileLocations.map(location => {
+        const normalizedLocation = location.replace(/^\//, '');
+        return `${normalizedLocation}/**/*.${extensionPattern}`;
+      }),
+      ...config.codeFileLocations.map(location => {
+        const normalizedLocation = location.replace(/^\//, '');
+        return `!${normalizedLocation}/**/*.spec.${extensionPattern}`;
+      }),
       '!node_modules/**',
     ];
 


### PR DESCRIPTION
Fixes an issue where only having configured a single file extension to be scanned, no translation keys would be found.