### PR TITLE
fix: enhance file path utility for cross-platform use

### DIFF
--- a/src/libs/util/util-file-path-utilities/src/lib/file-path-utilities.test.ts
+++ b/src/libs/util/util-file-path-utilities/src/lib/file-path-utilities.test.ts
@@ -32,6 +32,22 @@ suite('filePathUtilities', () => {
       assert.equal(locale, 'en');
     });
 
+    test('should extract the locale from a Mac OS file path', () => {
+      const config = {
+        i18nextScannerModule: {
+          translationFilesLocation: 'locales',
+        },
+      };
+
+      getConfigStub = sinon //NOSONAR
+        .stub(ConfigurationStoreManager.getInstance(), 'getConfig')
+        .returns(config.i18nextScannerModule);
+
+      const filePath = '/Users/someuser/project/locales/en/file.json';
+      const locale = filePathUtilities.extractLocale(filePath);
+      assert.equal(locale, 'en');
+    });
+
     test('should extract the locale from the file path with nested translation files location', () => {
       const config = {
         i18nextScannerModule: {
@@ -48,7 +64,7 @@ suite('filePathUtilities', () => {
       assert.equal(locale, 'en');
     });
 
-    test('should throw an error for invalid file path format', () => {
+    test('should throw an error when unable to extract locale from file path', () => {
       const config = {
         i18nextScannerModule: {
           translationFilesLocation: 'src/i18n',
@@ -61,7 +77,7 @@ suite('filePathUtilities', () => {
 
       const filePath = 'C:\\invalid\\file.path';
       assert.throws(() => filePathUtilities.extractLocale(filePath), {
-        message: 'Invalid file path format',
+        message: 'Unable to extract locale from file path.',
       });
     });
   });

--- a/src/libs/util/util-file-path-utilities/src/lib/file-path-utilities.ts
+++ b/src/libs/util/util-file-path-utilities/src/lib/file-path-utilities.ts
@@ -16,12 +16,12 @@ export function extractLocale(filePath: string): string {
       .pop() ?? '';
 
   const localePattern = new RegExp(
-    `\\\\${translationFilesLocation}\\\\([^\\\\]+)\\\\`
+    `[\\\\/]${translationFilesLocation}[\\\\/]([^\\\\/]+)[\\\\/]`
   );
 
   const match = localePattern.exec(filePath);
   if (!match || match.length < 2) {
-    throw new Error('Invalid file path format');
+    throw new Error('Unable to extract locale from file path.');
   }
   return match[1];
 }

--- a/src/libs/util/util-file-path-utilities/src/lib/file-path-utilities.ts
+++ b/src/libs/util/util-file-path-utilities/src/lib/file-path-utilities.ts
@@ -145,10 +145,10 @@ export function sanitizeLocations(locations: string[]): string[] {
   const sanitizedLocations: string[] = [];
 
   locations.forEach(location => {
-    location = location.endsWith('/')
+    location = location.endsWith(path.sep)
       ? location.substring(location.length)
       : location;
-    location = location.startsWith('/') ? location.substring(1) : location;
+    location = location.startsWith(path.sep) ? location.substring(1) : location;
 
     sanitizedLocations.push(location);
   });


### PR DESCRIPTION
Update extractLocale to support both Mac and Windows paths by adjusting the regex pattern.
Improve error handling message for locale extraction failures.
Add unit tests to cover Mac path scenarios.