### PR TITLE
fix: cross-platform path support magic

### DIFF
--- a/src/libs/feature/feature-translation-service/src/lib/translation-service.test.ts
+++ b/src/libs/feature/feature-translation-service/src/lib/translation-service.test.ts
@@ -91,10 +91,10 @@ suite('TranslationService', () => {
 
       readdirSyncStub.withArgs(parentDirectory).returns(['en', 'fr']);
       statSyncStub
-        .withArgs(`${parentDirectory}\\en`)
+        .withArgs(`${parentDirectory}${path.sep}en`)
         .returns({ isDirectory: () => true });
       statSyncStub
-        .withArgs(`${parentDirectory}\\fr`)
+        .withArgs(`${parentDirectory}${path.sep}fr`)
         .returns({ isDirectory: () => true });
       readdirSyncStub
         .withArgs(`${parentDirectory}${path.sep}en`)

--- a/src/libs/feature/feature-translation-service/src/lib/translation-service.test.ts
+++ b/src/libs/feature/feature-translation-service/src/lib/translation-service.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-syntax */
 import * as deepl from 'deepl-node';
 import assert from 'assert';
 import fs from 'fs';
@@ -15,8 +16,8 @@ import {
   ConfigurationStore,
   ConfigurationStoreManager,
   GeneralConfiguration,
+  TranslationModuleConfiguration,
 } from '@i18n-weave/util/util-configuration';
-import { TranslationModuleConfiguration } from '@i18n-weave/util/util-configuration';
 
 suite('TranslationService', () => {
   let extensionContext: vscode.ExtensionContext;

--- a/src/libs/feature/feature-translation-service/src/lib/translation-service.test.ts
+++ b/src/libs/feature/feature-translation-service/src/lib/translation-service.test.ts
@@ -1,6 +1,7 @@
 import * as deepl from 'deepl-node';
 import assert from 'assert';
 import fs from 'fs';
+import path from 'path';
 import sinon from 'sinon';
 import vscode from 'vscode';
 
@@ -84,8 +85,8 @@ suite('TranslationService', () => {
 
   suite('getOtherTranslationFilesPaths', () => {
     test('should return paths of other translation files', () => {
-      const fileLocation = 'C:\\projects\\translations\\en\\file.json';
-      const parentDirectory = 'C:\\projects\\translations';
+      const fileLocation = `C:${path.sep}projects${path.sep}translations${path.sep}en${path.sep}file.json`;
+      const parentDirectory = `C:${path.sep}projects${path.sep}translations`;
 
       readdirSyncStub.withArgs(parentDirectory).returns(['en', 'fr']);
       statSyncStub
@@ -94,63 +95,74 @@ suite('TranslationService', () => {
       statSyncStub
         .withArgs(`${parentDirectory}\\fr`)
         .returns({ isDirectory: () => true });
-      readdirSyncStub.withArgs(`${parentDirectory}\\en`).returns(['file.json']);
-      readdirSyncStub.withArgs(`${parentDirectory}\\fr`).returns(['file.json']);
+      readdirSyncStub
+        .withArgs(`${parentDirectory}${path.sep}en`)
+        .returns(['file.json']);
+      readdirSyncStub
+        .withArgs(`${parentDirectory}${path.sep}fr`)
+        .returns(['file.json']);
 
       const result =
         translationService.getOtherTranslationFilesPaths(fileLocation);
 
       assert.deepStrictEqual(result, [
-        'C:\\projects\\translations\\fr\\file.json',
+        `C:${path.sep}projects${path.sep}translations${path.sep}fr${path.sep}file.json`,
       ]);
     });
 
     test('should exclude the original file from the result', () => {
-      const fileLocation = 'C:\\projects\\translations\\en\\file.json';
-      const parentDirectory = 'C:\\projects\\translations';
+      const fileLocation = `C:${path.sep}projects${path.sep}translations${path.sep}en${path.sep}file.json`;
+      const parentDirectory = `C:${path.sep}projects${path.sep}translations`;
 
       readdirSyncStub.withArgs(parentDirectory).returns(['en', 'fr']);
       statSyncStub
-        .withArgs(`${parentDirectory}\\en`)
+        .withArgs(`${parentDirectory}${path.sep}en`)
         .returns({ isDirectory: () => true });
       statSyncStub
-        .withArgs(`${parentDirectory}\\fr`)
+        .withArgs(`${parentDirectory}${path.sep}fr`)
         .returns({ isDirectory: () => true });
-      readdirSyncStub.withArgs(`${parentDirectory}\\en`).returns(['file.json']);
-      readdirSyncStub.withArgs(`${parentDirectory}\\fr`).returns(['file.json']);
+      readdirSyncStub
+        .withArgs(`${parentDirectory}${path.sep}en`)
+        .returns(['file.json']);
+      readdirSyncStub
+        .withArgs(`${parentDirectory}${path.sep}fr`)
+        .returns(['file.json']);
 
       const result =
         translationService.getOtherTranslationFilesPaths(fileLocation);
 
       assert.deepStrictEqual(result, [
-        'C:\\projects\\translations\\fr\\file.json',
+        `C:${path.sep}projects${path.sep}translations${path.sep}fr${path.sep}file.json`,
       ]);
     });
   });
 
   suite('translateOtherI18nFiles', () => {
     test.skip('should translate missing keys in other i18n files', async () => {
-      const fileLocation = 'C:\\projects\\translations\\en\\file.json';
+      const fileLocation = `C:${path.sep}projects${path.sep}translations${path.sep}en${path.sep}file.json`;
       const changedFileContent = JSON.stringify({ key1: 'value1' });
 
       readdirSyncStub
-        .withArgs('C:\\projects\\translations')
+        .withArgs(`C:${path.sep}projects${path.sep}translations`)
         .returns(['en', 'fr']);
       statSyncStub
-        .withArgs('C:\\projects\\translations\\en')
+        .withArgs(`C:${path.sep}projects${path.sep}translations${path.sep}en`)
         .returns({ isDirectory: () => true });
       statSyncStub
-        .withArgs('C:\\projects\\translations\\fr')
+        .withArgs(`C:${path.sep}projects${path.sep}translations${path.sep}fr`)
         .returns({ isDirectory: () => true });
       readdirSyncStub
-        .withArgs('C:\\projects\\translations\\en')
+        .withArgs(`C:${path.sep}projects${path.sep}translations${path.sep}en`)
         .returns(['file.json']);
       readdirSyncStub
-        .withArgs('C:\\projects\\translations\\fr')
+        .withArgs(`C:${path.sep}projects${path.sep}translations${path.sep}fr`)
         .returns(['file.json']);
 
       readFileSyncStub
-        .withArgs('C:\\projects\\translations\\fr\\file.json', 'utf-8')
+        .withArgs(
+          `C:${path.sep}projects${path.sep}translations${path.sep}fr${path.sep}file.json`,
+          'utf-8'
+        )
         .returns(JSON.stringify({ key1: '' }));
       fetchTranslationStub.withArgs('value1', 'fr').resolves('valeur1');
 
@@ -161,34 +173,37 @@ suite('TranslationService', () => {
 
       assert(
         writeFileSyncStub.calledWith(
-          'C:\\projects\\translations\\fr\\file.json',
+          `C:${path.sep}projects${path.sep}translations${path.sep}fr${path.sep}file.json`,
           JSON.stringify({ key1: 'valeur1' }, null, 2)
         )
       );
     });
 
     test('should not update keys that are not missing', async () => {
-      const fileLocation = 'C:\\projects\\translations\\en\\file.json';
+      const fileLocation = `C:${path.sep}projects${path.sep}translations${path.sep}en${path.sep}file.json`;
       const changedFileContent = JSON.stringify({ key1: 'value1' });
 
       readdirSyncStub
-        .withArgs('C:\\projects\\translations')
+        .withArgs(`C:${path.sep}projects${path.sep}translations`)
         .returns(['en', 'fr']);
       statSyncStub
-        .withArgs('C:\\projects\\translations\\en')
+        .withArgs(`C:${path.sep}projects${path.sep}translations${path.sep}en`)
         .returns({ isDirectory: () => true });
       statSyncStub
-        .withArgs('C:\\projects\\translations\\fr')
+        .withArgs(`C:${path.sep}projects${path.sep}translations${path.sep}fr`)
         .returns({ isDirectory: () => true });
       readdirSyncStub
-        .withArgs('C:\\projects\\translations\\en')
+        .withArgs(`C:${path.sep}projects${path.sep}translations${path.sep}en`)
         .returns(['file.json']);
       readdirSyncStub
-        .withArgs('C:\\projects\\translations\\fr')
+        .withArgs(`C:${path.sep}projects${path.sep}translations${path.sep}fr`)
         .returns(['file.json']);
 
       readFileSyncStub
-        .withArgs('C:\\projects\\translations\\fr\\file.json', 'utf-8')
+        .withArgs(
+          `C:${path.sep}projects${path.sep}translations${path.sep}fr${path.sep}file.json`,
+          'utf-8'
+        )
         .returns(JSON.stringify({ key1: 'existingValue' }));
       fetchTranslationStub.withArgs('value1', 'fr').resolves('valeur1');
 
@@ -201,27 +216,30 @@ suite('TranslationService', () => {
     });
 
     test.skip('should handle nested missing keys', async () => {
-      const fileLocation = 'C:\\projects\\translations\\en\\file.json';
+      const fileLocation = `C:${path.sep}projects${path.sep}translations${path.sep}en${path.sep}file.json`;
       const changedFileContent = JSON.stringify({ key1: { subKey: 'value1' } });
 
       readdirSyncStub
-        .withArgs('C:\\projects\\translations')
+        .withArgs(`C:${path.sep}projects${path.sep}translations`)
         .returns(['en', 'fr']);
       statSyncStub
-        .withArgs('C:\\projects\\translations\\en')
+        .withArgs(`C:${path.sep}projects${path.sep}translations${path.sep}en`)
         .returns({ isDirectory: () => true });
       statSyncStub
-        .withArgs('C:\\projects\\translations\\fr')
+        .withArgs(`C:${path.sep}projects${path.sep}translations${path.sep}fr`)
         .returns({ isDirectory: () => true });
       readdirSyncStub
-        .withArgs('C:\\projects\\translations\\en')
+        .withArgs(`C:${path.sep}projects${path.sep}translations${path.sep}en`)
         .returns(['file.json']);
       readdirSyncStub
-        .withArgs('C:\\projects\\translations\\fr')
+        .withArgs(`C:${path.sep}projects${path.sep}translations${path.sep}fr`)
         .returns(['file.json']);
 
       readFileSyncStub
-        .withArgs('C:\\projects\\translations\\fr\\file.json', 'utf-8')
+        .withArgs(
+          `C:${path.sep}projects${path.sep}translations${path.sep}fr${path.sep}file.json`,
+          'utf-8'
+        )
         .returns(JSON.stringify({ key1: { subKey: '' } }));
       fetchTranslationStub.withArgs('value1', 'fr').resolves('valeur1');
 
@@ -232,7 +250,7 @@ suite('TranslationService', () => {
 
       assert(
         writeFileSyncStub.calledWith(
-          'C:\\projects\\translations\\fr\\file.json',
+          `C:${path.sep}projects${path.sep}translations${path.sep}fr${path.sep}file.json`,
           JSON.stringify({ key1: { subKey: 'valeur1' } }, null, 2)
         )
       );

--- a/src/libs/feature/feature-translation-service/src/lib/translation-service.ts
+++ b/src/libs/feature/feature-translation-service/src/lib/translation-service.ts
@@ -3,6 +3,8 @@ import vscode from 'vscode';
 
 import { DeeplClient } from '@i18n-weave/http/http-deepl-client';
 
+const path = require('path');
+
 /**
  * Singleton class for managing translation services.
  */
@@ -34,18 +36,26 @@ export class TranslationService {
    * @returns An array of file paths for other translation files.
    */
   public getOtherTranslationFilesPaths(fileLocation: string): string[] {
-    const directory = fileLocation.substring(0, fileLocation.lastIndexOf('\\'));
-    const parentDirectory = directory.substring(0, directory.lastIndexOf('\\'));
-    const fileName = fileLocation.substring(fileLocation.lastIndexOf('\\') + 1);
+    const directory = fileLocation.substring(
+      0,
+      fileLocation.lastIndexOf(path.sep)
+    );
+    const parentDirectory = directory.substring(
+      0,
+      directory.lastIndexOf(path.sep)
+    );
+    const fileName = fileLocation.substring(
+      fileLocation.lastIndexOf(path.sep) + 1
+    );
 
     const files: string[] = [];
     fs.readdirSync(parentDirectory).forEach(file => {
-      const filePath = `${parentDirectory}\\${file}`;
+      const filePath = `${parentDirectory}${path.sep}${file}`;
       const stat = fs.statSync(filePath);
       if (stat.isDirectory()) {
         fs.readdirSync(filePath).forEach(subFile => {
           if (subFile === fileName) {
-            files.push(`${filePath}\\${subFile}`);
+            files.push(`${filePath}${path.sep}${subFile}`);
           }
         });
       }
@@ -185,7 +195,7 @@ export class TranslationService {
   }
 
   private getLocaleFromFilePath(filePath: string): string {
-    const parts = filePath.split('\\');
+    const parts = filePath.split(path.sep);
     return parts[parts.length - 2];
   }
 

--- a/src/libs/feature/feature-translation-service/src/lib/translation-service.ts
+++ b/src/libs/feature/feature-translation-service/src/lib/translation-service.ts
@@ -1,9 +1,8 @@
 import fs from 'fs';
+import path from 'path';
 import vscode from 'vscode';
 
 import { DeeplClient } from '@i18n-weave/http/http-deepl-client';
-
-const path = require('path');
 
 /**
  * Singleton class for managing translation services.


### PR DESCRIPTION
Bids farewell to pesky Windows-only paths by splitting paths 
using a cross-platform approach! Now, your i18nWeave 
plays nice with all operating systems.