### PR TITLE
perf(performance): prevent unnecessary file scans

### DIFF
--- a/src/libs/feature/feature-file-watcher-creator/src/lib/file-watcher-creator.ts
+++ b/src/libs/feature/feature-file-watcher-creator/src/lib/file-watcher-creator.ts
@@ -1,4 +1,5 @@
 import * as vscode from 'vscode';
+import { FileLocationStore } from 'src/libs/store/store-file-location-store/src';
 
 import { FileChangeHandlerFactory } from '@i18n-weave/feature/feature-file-change-handler-factory';
 
@@ -41,19 +42,25 @@ export class FileWatcherCreator {
 
     fileWatcher.onDidCreate(async uri => {
       if (!disableFlags.some(flag => flag())) {
-        await fileChangeHandler?.handleFileCreationAsync(uri);
+        if (FileLocationStore.getInstance().hasFile(uri)) {
+          await fileChangeHandler?.handleFileCreationAsync(uri);
+        }
       }
     });
 
     fileWatcher.onDidDelete(async uri => {
       if (!disableFlags.some(flag => flag())) {
-        await fileChangeHandler?.handleFileDeletionAsync(uri);
+        if (FileLocationStore.getInstance().hasFile(uri)) {
+          await fileChangeHandler?.handleFileDeletionAsync(uri);
+        }
       }
     });
 
     fileWatcher.onDidChange(async uri => {
       if (!disableFlags.some(flag => flag())) {
-        await fileChangeHandler?.handleFileChangeAsync(uri);
+        if (FileLocationStore.getInstance().hasFile(uri)) {
+          await fileChangeHandler?.handleFileChangeAsync(uri);
+        }
       }
     });
 


### PR DESCRIPTION
### Description

This pull request introduces a performance improvement by adding a check using `FileLocationStore` to determine whether a file needs to be scanned before handling file-related events such as creation, deletion, or modifications. The change ensures that only files that are not ignored and are present in the store are processed, thereby eliminating unnecessary operations on files that should be ignored. This enhancement results in improved performance and increased reliability of file event handling by reducing the overhead associated with scanning non-existent files.

### Impact

- Reduce the amount of unnecessary code file scans, improving overall performance.