### PR TITLE
refactor: remove unused code and stubs from tests

### DIFF
--- a/src/libs/feature/feature-base-file-change-handler/src/lib/base-file-change-handler.ts
+++ b/src/libs/feature/feature-base-file-change-handler/src/lib/base-file-change-handler.ts
@@ -2,8 +2,6 @@ import { Uri } from 'vscode';
 
 import { FileLocationStore } from '@i18n-weave/store/store-file-location-store';
 
-import { Logger } from '@i18n-weave/util/util-logger';
-
 export abstract class BaseFileChangeHandler {
   public abstract handleFileChangeAsync(
     changeFileLocation?: Uri | undefined

--- a/src/libs/feature/feature-diagnostics-manager/src/lib/diagnostics-manager.test.ts
+++ b/src/libs/feature/feature-diagnostics-manager/src/lib/diagnostics-manager.test.ts
@@ -7,10 +7,8 @@ import { ConfigurationStoreManager } from '@i18n-weave/util/util-configuration';
 import { DiagnosticsManager } from './diagnostics-manager';
 
 suite('DiagnosticsManager', () => {
-  let getConfigStub: sinon.SinonStub;
   let sandbox: sinon.SinonSandbox;
   let diagnosticCollectionStub: sinon.SinonStubbedInstance<vscode.DiagnosticCollection>;
-  let createDiagnosticCollectionStub: sinon.SinonStub;
 
   setup(() => {
     sandbox = sinon.createSandbox();
@@ -23,7 +21,7 @@ suite('DiagnosticsManager', () => {
       has: sandbox.stub(),
       name: 'missingValues',
     } as unknown as sinon.SinonStubbedInstance<vscode.DiagnosticCollection>;
-    createDiagnosticCollectionStub = sandbox
+    sandbox
       .stub(vscode.languages, 'createDiagnosticCollection')
       .returns(diagnosticCollectionStub);
   });
@@ -33,7 +31,7 @@ suite('DiagnosticsManager', () => {
   });
 
   test('should update diagnostics with empty value errors', async () => {
-    getConfigStub = sinon
+    sinon
       .stub(ConfigurationStoreManager.getInstance(), 'getConfig')
       .withArgs('debugging')
       .returns({
@@ -61,23 +59,6 @@ suite('DiagnosticsManager', () => {
     const instance1 = DiagnosticsManager.getInstance();
     const instance2 = DiagnosticsManager.getInstance();
     assert.strictEqual(instance1, instance2);
-  });
-
-  test('should update diagnostics with empty value errors', async () => {
-    const manager = DiagnosticsManager.getInstance();
-
-    // @ts-ignore
-    manager._diagnosticCollection = diagnosticCollectionStub;
-
-    const document = { uri: 'test-uri' } as unknown as vscode.TextDocument;
-    const documentSymbols = [
-      { name: 'key1', range: new vscode.Range(0, 0, 0, 5) },
-      { name: 'key2', range: new vscode.Range(1, 0, 1, 5) },
-    ] as vscode.DocumentSymbol[];
-
-    await manager.updateDiagnostics(document, documentSymbols);
-
-    assert.ok(diagnosticCollectionStub.set.calledOnce);
   });
 
   test('should clear diagnostics if no issues are found', async () => {


### PR DESCRIPTION
### Description

This pull request focuses on cleaning up the codebase by removing unused code and stubs from the test modules. The main goal is to improve clarity and maintainability by eliminating elements that are not contributing to the current functionality.

### Changes

- Removed unused stubs and test cases from the `diagnostics-manager` tests, thereby simplifying them and enhancing their readability.
- Eliminated an unused `Logger` import from the `base-file-change-handler`, cleans up the code and reduces potential confusion for future code maintenance.

### Impact

By eliminating unused code, we reduce clutter, which simplifies future modifications and aids in maintaining high code quality. There should be no functional change or impact to current operations, as the removed code was not actively used.