### PR TITLE
chore(logger): update timestamp format for clarity

### DIFF
--- a/src/libs/util/util-logger/src/lib/logger.ts
+++ b/src/libs/util/util-logger/src/lib/logger.ts
@@ -42,7 +42,17 @@ export class Logger {
       return;
     }
 
-    const timestamp = new Date().toISOString();
+    const timestamp = new Date()
+      .toLocaleString('en-GB', {
+        day: '2-digit',
+        month: '2-digit',
+        year: 'numeric',
+        hour: '2-digit',
+        minute: '2-digit',
+        second: '2-digit',
+        hour12: false,
+      })
+      .replace(',', '');
     const formattedMessage = scope
       ? `[${level}] [${scope}] ${timestamp}: ${message}`
       : `[${level}] ${timestamp}: ${message}`;


### PR DESCRIPTION
### Description

This pull request updates the format of timestamps in logger messages to a UK date-time format. The previous ISO 8601 format has been replaced with a locale-based format to improve clarity and readability for users who prefer the UK style of date representation. This change aims to enhance user experience by providing a more intuitive date display.