### PR TITLE
fix(module-translation): ensure valid path before applying change

### DIFF
--- a/src/libs/module/module-translation/src/lib/translation-module.ts
+++ b/src/libs/module/module-translation/src/lib/translation-module.ts
@@ -228,7 +228,16 @@ export class TranslationModule extends BaseActionModule {
           unset(target, path);
         }
       } else if (change.kind === 'E' || change.kind === 'A') {
-        applyChange(target, change);
+        if (change.path) {
+          const targetValue = change.path.reduce(
+            (obj, key) => obj?.[key],
+            target
+          );
+
+          if (targetValue !== undefined) {
+            applyChange(target, change);
+          }
+        }
       }
     });
   }


### PR DESCRIPTION
### Description

This pull request addresses a bug in the translation module where changes were being applied without ensuring the validity of the target path. The issue primarily affects scenarios involving multiple plural forms in different languages, leading to incorrect entries in language resource files.

### Changes

- Implemented a check for the existence of target values before applying changes. This ensures that translations are processed only for valid paths, preventing the addition of unnecessary plural forms to language resource files.
- Improved handling of pluralisation in languages with varying numbers of plural forms to maintain the integrity of the translation data.

### Impact

By ensuring that changes are applied only to valid paths, this fix prevents potential issues with unused or incorrect translations, particularly benefiting projects utilizing multiple languages with different plural form requirements. This leads to cleaner and more accurate translation resource files, which is crucial for maintaining a consistent multilingual user experience.