### PR TITLE
fix: add i18nWeave config option for project root path

### DIFF
--- a/package.json
+++ b/package.json
@@ -222,6 +222,11 @@
             "type": "boolean",
             "default": false,
             "description": "Enable the Json File Web View. This feature is still in beta and may not work as expected."
+          },
+          "i18nWeave.relativePathToProjectRoot": {
+            "type": "string",
+            "default": "",
+            "markdownDescription": "Relative path to the project root. Example: `my-project\\frontend`\n\nThis path will be used to resolve relative paths in the i18next-scanner module.\nYou can use 'Copy Relative Path' from the context menu in the file explorer to copy the relative path to the clipboard."
           }
         }
       },

--- a/src/libs/feature/feature-i18next-scanner-service/src/lib/i18next-scanner-service.ts
+++ b/src/libs/feature/feature-i18next-scanner-service/src/lib/i18next-scanner-service.ts
@@ -1,5 +1,6 @@
 import sort from 'gulp-sort';
 import I18nextScanner from 'i18next-scanner';
+import path from 'path';
 import vfs from 'vinyl-fs';
 
 import {
@@ -13,7 +14,7 @@ import {
   I18nextScannerModuleConfiguration,
 } from '@i18n-weave/util/util-configuration';
 import { TraceMethod } from '@i18n-weave/util/util-decorators';
-import { getProjectRootFolder } from '@i18n-weave/util/util-file-path-utilities';
+import { getWorkspaceRoot } from '@i18n-weave/util/util-file-path-utilities';
 import { LogLevel, Logger } from '@i18n-weave/util/util-logger';
 
 import { I18nextScannerOptions } from './i18nextScannerOptions';
@@ -64,9 +65,14 @@ export class I18nextScannerService {
       );
     const generalConfig =
       configManager.getConfig<GeneralConfiguration>('general');
-    let projectRoot = getProjectRootFolder();
+    let workspaceRoot = getWorkspaceRoot();
+    let relativePathToProjectRoot = generalConfig.relativePathToProjectRoot;
+    let absolutePathToProjectRoot = path.join(
+      workspaceRoot.fsPath,
+      relativePathToProjectRoot
+    );
 
-    if (!projectRoot) {
+    if (!workspaceRoot) {
       this._logger.log(
         LogLevel.ERROR,
         'No project root found',
@@ -93,8 +99,8 @@ export class I18nextScannerService {
       defaultNs: i18nNextScannerModuleConfiguration.defaultNamespace,
       defaultValue: '',
       resource: {
-        loadPath: `${projectRoot.fsPath}/${i18nNextScannerModuleConfiguration.translationFilesLocation}/{{lng}}/{{ns}}.json`,
-        savePath: `${projectRoot.fsPath}/${i18nNextScannerModuleConfiguration.translationFilesLocation}/{{lng}}/{{ns}}.json`,
+        loadPath: `${absolutePathToProjectRoot}${i18nNextScannerModuleConfiguration.translationFilesLocation}/{{lng}}/{{ns}}.json`,
+        savePath: `${absolutePathToProjectRoot}${i18nNextScannerModuleConfiguration.translationFilesLocation}/{{lng}}/{{ns}}.json`,
         jsonIndent: generalConfig.format.numberOfSpacesForIndentation,
         lineEnding: 'CRLF',
       },
@@ -144,7 +150,7 @@ export class I18nextScannerService {
       '!node_modules/**',
     ];
 
-    this.executeScanner(options, projectRoot.fsPath, scanSources);
+    this.executeScanner(options, absolutePathToProjectRoot, scanSources);
 
     this._logger.log(
       LogLevel.INFO,

--- a/src/libs/util/util-configuration/src/lib/general/general-configuration.ts
+++ b/src/libs/util/util-configuration/src/lib/general/general-configuration.ts
@@ -8,4 +8,5 @@ export class GeneralConfiguration {
   betaFeaturesConfiguration: BetaFeaturesConfiguration =
     new BetaFeaturesConfiguration();
   format: FormatConfiguration = new FormatConfiguration();
+  relativePathToProjectRoot: string = '';
 }

--- a/src/libs/util/util-file-path-utilities/src/lib/file-path-utilities.test.ts
+++ b/src/libs/util/util-file-path-utilities/src/lib/file-path-utilities.test.ts
@@ -237,7 +237,7 @@ suite('filePathUtilities', () => {
       const workspaceFolder = {
         uri: vscode.Uri.file('c:\\workspace'),
       } as vscode.WorkspaceFolder;
-      const projectDir = path.join(workspaceFolder.uri.fsPath, 'project');
+      const projectDir = path.join(workspaceFolder.uri.fsPath);
 
       sinon.stub(vscode.workspace, 'workspaceFolders').value([workspaceFolder]);
       sinon.stub(fs, 'existsSync').callsFake(p => {
@@ -268,24 +268,7 @@ suite('filePathUtilities', () => {
     });
 
     test('should throw an error if no project root is found', () => {
-      const rootDir = 'c:\\workspace';
-      const workspaceFolder = {
-        uri: vscode.Uri.file(rootDir),
-      } as vscode.WorkspaceFolder;
-
-      sinon.stub(vscode.workspace, 'workspaceFolders').value([workspaceFolder]);
-      sinon.stub(fs, 'existsSync').returns(false);
-      sinon.stub(fs, 'lstatSync').callsFake((p): any => {
-        return {
-          isDirectory: () => p === rootDir, //NOSONAR
-        };
-      });
-      sinon.stub(fs, 'readdirSync').callsFake((dir): any => {
-        if (dir === rootDir) {
-          return ['project'];
-        }
-      });
-
+      sinon.stub(vscode.workspace, 'workspaceFolders').value([]);
       assert.throws(
         () => {
           filePathUtilities.getWorkspaceRoot();
@@ -295,19 +278,17 @@ suite('filePathUtilities', () => {
         }
       );
     });
+
+    test('should throw an error if multiple workspace folders are found', () => {
+      sinon.stub(vscode.workspace, 'workspaceFolders').value(['', '']);
+      assert.throws(
+        () => {
+          filePathUtilities.getWorkspaceRoot();
+        },
+        {
+          message: 'Multiple workspace folders are not supported',
+        }
+      );
+    });
   });
-
-  // suite('getRelativePath', () => {
-  //   test('should get the relative path of a folder from the project root folder', () => {
-  //     const projectRootFolder = 'C:\\workspace\\project';
-  //     const folderPath = 'C:\\workspace\\project\\src\\components';
-
-  //     sinon
-  //       .stub(filePathUtilities, 'getProjectRootFolder')
-  //       .returns(projectRootFolder);
-
-  //     const relativePath = filePathUtilities.getRelativePath(folderPath);
-  //     assert.strictEqual(relativePath, 'src/components');
-  //   });
-  // });
 });

--- a/src/libs/util/util-file-path-utilities/src/lib/file-path-utilities.test.ts
+++ b/src/libs/util/util-file-path-utilities/src/lib/file-path-utilities.test.ts
@@ -263,7 +263,7 @@ suite('filePathUtilities', () => {
         return [];
       });
 
-      const projectRoot = filePathUtilities.getProjectRootFolder();
+      const projectRoot = filePathUtilities.getWorkspaceRoot();
       assert.strictEqual(projectRoot.fsPath, projectDir);
     });
 
@@ -288,7 +288,7 @@ suite('filePathUtilities', () => {
 
       assert.throws(
         () => {
-          filePathUtilities.getProjectRootFolder();
+          filePathUtilities.getWorkspaceRoot();
         },
         {
           message: 'Project root folder not found',

--- a/src/libs/util/util-file-path-utilities/src/lib/file-path-utilities.ts
+++ b/src/libs/util/util-file-path-utilities/src/lib/file-path-utilities.ts
@@ -139,16 +139,11 @@ export function findProjectRoot(dir: Uri): Uri | undefined {
  * Get the actual project root folder by locating the package.json file.
  * @returns The path to the project root folder or undefined if not found.
  */
-export function getProjectRootFolder(): Uri {
+export function getWorkspaceRoot(): Uri {
   const workspaceFolders = vscode.workspace.workspaceFolders;
 
   if (workspaceFolders) {
-    for (const folder of workspaceFolders) {
-      const projectRoot = findProjectRoot(folder.uri);
-      if (projectRoot) {
-        return projectRoot;
-      }
-    }
+    return workspaceFolders[0].uri;
   }
 
   throw new Error('Project root folder not found');
@@ -199,7 +194,7 @@ export function sanitizeLocations(fileFsPaths: string[]): string[] {
  */
 //TODO: find out why this doesn't actually return a relative path
 export function getRelativePath(folderPath: Uri) {
-  const projectRootFolder = getProjectRootFolder();
+  const projectRootFolder = getWorkspaceRoot();
 
   return getPosixPathFromUri(
     folderPath.fsPath.replace(projectRootFolder.fsPath, '')

--- a/src/libs/util/util-file-path-utilities/src/lib/file-path-utilities.ts
+++ b/src/libs/util/util-file-path-utilities/src/lib/file-path-utilities.ts
@@ -142,8 +142,12 @@ export function findProjectRoot(dir: Uri): Uri | undefined {
 export function getWorkspaceRoot(): Uri {
   const workspaceFolders = vscode.workspace.workspaceFolders;
 
-  if (workspaceFolders) {
+  if (workspaceFolders?.length === 1) {
     return workspaceFolders[0].uri;
+  }
+
+  if (workspaceFolders && workspaceFolders.length > 1) {
+    throw new Error('Multiple workspace folders are not supported');
   }
 
   throw new Error('Project root folder not found');


### PR DESCRIPTION
### Description

This pull request addresses a problem with determining the project root path for the i18nWeave configuration. The current logic sometimes fails to identify the root directory, leading to no output or code scan results.

### Changes

- Introduced a new configuration option `i18nWeave.relativePathToProjectRoot`, which allows users to specify a relative path to the project root directory.
- This change ensures that the tool can correctly resolve the project root path when it cannot be determined automatically.

### Impact

This update is expected to resolve issues related to incorrect or failed path resolutions for projects where the root path is not being properly identified. Users will need to adjust their configurations to utilize the new `relativePathToProjectRoot` option as necessary. This should enhance the effectiveness of code scanning features reliant on accurate path information.