### PR TITLE
add-translation-key-hover-provider

### DIFF
--- a/src/core/extension.ts
+++ b/src/core/extension.ts
@@ -14,6 +14,7 @@ import {
 import { TextDocumentChangedHandler } from '@i18n-weave/feature/feature-text-document-changed-handler';
 // import { TranslationDefinitionProvider } from '@i18n-weave/feature/feature-translation-definition-provider';
 import { TranslationKeyCompletionProvider } from '@i18n-weave/feature/feature-translation-key-completion-provider';
+import { TranslationKeyHoverProvider } from '@i18n-weave/feature/feature-translation-key-hover-provider';
 
 import { TranslationStore } from '@i18n-weave/store/store-translation-store';
 
@@ -122,7 +123,8 @@ export async function activate(
       ConfigurationStoreManager.getInstance().getConfig<I18nextScannerModuleConfiguration>(
         'i18nextScannerModule'
       );
-    const provider = TranslationKeyCompletionProvider.getInstance();
+    const translationKeyCompletionProvider =
+      TranslationKeyCompletionProvider.getInstance();
     const completionItemProviderDisposable =
       vscode.languages.registerCompletionItemProvider(
         [
@@ -131,12 +133,24 @@ export async function activate(
           { language: 'javascriptreact', scheme: 'file' }, // For .jsx files
           { language: 'typescriptreact', scheme: 'file' }, // For .tsx files
         ], // Adjust languages as needed
-        provider,
+        translationKeyCompletionProvider,
         "'",
         '"',
         i18nextScannerModuleConfiguration.nsSeparator,
         i18nextScannerModuleConfiguration.keySeparator
       );
+
+    const translationKeyHoverProvider =
+      TranslationKeyHoverProvider.getInstance();
+    const hoverProviderDisposable = vscode.languages.registerHoverProvider(
+      [
+        { language: 'javascript', scheme: 'file' },
+        { language: 'typescript', scheme: 'file' },
+        { language: 'javascriptreact', scheme: 'file' }, // For .jsx files
+        { language: 'typescriptreact', scheme: 'file' }, // For .tsx files
+      ],
+      translationKeyHoverProvider
+    );
 
     // const definitionProvider = TranslationDefinitionProvider.getInstance();
     // const translationDefinitionProviderDisposable =
@@ -159,7 +173,8 @@ export async function activate(
       onDidChangeTextDocumentDisposable,
       configurationWizardCommandDisposable,
       configurationWatcherDisposable,
-      completionItemProviderDisposable
+      completionItemProviderDisposable,
+      hoverProviderDisposable
       // translationDefinitionProviderDisposable
     );
 

--- a/src/libs/feature/feature-translation-key-completion-provider/src/lib/translation-key-completion-provider.test.ts
+++ b/src/libs/feature/feature-translation-key-completion-provider/src/lib/translation-key-completion-provider.test.ts
@@ -1,2 +1,109 @@
+import * as assert from 'assert';
+import * as sinon from 'sinon';
+import * as vscode from 'vscode';
+
+import { FileLocationStore } from '@i18n-weave/store/store-file-location-store';
+
+import { ConfigurationStoreManager } from '@i18n-weave/util/util-configuration';
+
+import { TranslationKeyCompletionProvider } from './translation-key-completion-provider';
+
 /* eslint-disable no-restricted-imports */
 // Tests for TranslationKeyCompletionProvider
+suite('TranslationKeyCompletionProvider Tests', () => {
+  let provider: TranslationKeyCompletionProvider;
+  let fileLocationStoreStub: sinon.SinonStubbedInstance<FileLocationStore>;
+  let configurationStoreManagerStub: sinon.SinonStubbedInstance<ConfigurationStoreManager>;
+
+  setup(() => {
+    provider = TranslationKeyCompletionProvider.getInstance();
+    fileLocationStoreStub = sinon.createStubInstance(FileLocationStore);
+    configurationStoreManagerStub = sinon.createStubInstance(
+      ConfigurationStoreManager
+    );
+
+    sinon.stub(FileLocationStore, 'getInstance').returns(fileLocationStoreStub);
+    sinon
+      .stub(ConfigurationStoreManager, 'getInstance')
+      .returns(configurationStoreManagerStub);
+  });
+
+  teardown(() => {
+    sinon.restore();
+  });
+
+  test('provideCompletionItems should return completion items', async () => {
+    const document = {
+      lineAt: sinon.stub().returns({ text: 't("namespace:key")' }),
+      getWordRangeAtPosition: sinon
+        .stub()
+        .returns(new vscode.Range(0, 15, 0, 15)),
+    } as unknown as vscode.TextDocument;
+    const position = new vscode.Position(0, 15);
+
+    configurationStoreManagerStub.getConfig.returns({
+      translationFunctionNames: ['t'],
+      nsSeparator: ':',
+      defaultNamespace: 'default',
+      defaultLanguage: 'en',
+      contextSeparator: '_',
+      pluralSeparator: '_plural',
+    });
+
+    fileLocationStoreStub.getTranslationKeys.returns(['key1', 'key2']);
+
+    const items = await provider.provideCompletionItems(document, position);
+
+    assert.strictEqual(items!.length, 2);
+    assert.strictEqual(items![0].label, 'namespace:key1');
+    assert.strictEqual(items![1].label, 'namespace:key2');
+  });
+
+  test('resolveCompletionItem should set documentation', async () => {
+    const item = new vscode.CompletionItem('namespace:key');
+    item.detail = JSON.stringify({
+      namespace: 'namespace',
+      translationKey: 'key',
+    });
+
+    configurationStoreManagerStub.getConfig.returns({
+      defaultLanguage: 'en',
+    });
+
+    fileLocationStoreStub.getTranslationValue.returns('Translation Value');
+
+    const resolvedItem = await provider.resolveCompletionItem(
+      item,
+      {} as vscode.CancellationToken
+    );
+
+    assert.strictEqual(
+      (resolvedItem!.documentation as vscode.MarkdownString).value,
+      '`namespace: namespace`\n\nTranslation Value'
+    );
+  });
+
+  test('resolveCompletionItem should handle missing translation value', async () => {
+    const item = new vscode.CompletionItem('namespace:key');
+    item.detail = JSON.stringify({
+      namespace: 'namespace',
+      translationKey: 'key',
+    });
+
+    configurationStoreManagerStub.getConfig.returns({
+      defaultLanguage: 'en',
+    });
+
+    fileLocationStoreStub.getTranslationValue.returns(undefined);
+
+    const resolvedItem = await provider.resolveCompletionItem(
+      item,
+      {} as vscode.CancellationToken
+    );
+
+    assert.strictEqual(
+      (resolvedItem!.documentation as vscode.MarkdownString).value,
+      '`namespace: namespace`\n\n*No translation value found*'
+    );
+  });
+});

--- a/src/libs/feature/feature-translation-key-hover-provider/src/index.ts
+++ b/src/libs/feature/feature-translation-key-hover-provider/src/index.ts
@@ -1,0 +1,1 @@
+export * from './lib/translation-key-hover-provider';

--- a/src/libs/feature/feature-translation-key-hover-provider/src/lib/translation-key-hover-provider.test.ts
+++ b/src/libs/feature/feature-translation-key-hover-provider/src/lib/translation-key-hover-provider.test.ts
@@ -1,0 +1,2 @@
+/* eslint-disable no-restricted-imports */
+// Tests for TranslationKeyHoverProvider

--- a/src/libs/feature/feature-translation-key-hover-provider/src/lib/translation-key-hover-provider.test.ts
+++ b/src/libs/feature/feature-translation-key-hover-provider/src/lib/translation-key-hover-provider.test.ts
@@ -1,2 +1,0 @@
-/* eslint-disable no-restricted-imports */
-// Tests for TranslationKeyHoverProvider

--- a/src/libs/feature/feature-translation-key-hover-provider/src/lib/translation-key-hover-provider.ts
+++ b/src/libs/feature/feature-translation-key-hover-provider/src/lib/translation-key-hover-provider.ts
@@ -1,0 +1,102 @@
+import {
+  CancellationToken,
+  Hover,
+  HoverProvider,
+  Position,
+  ProviderResult,
+  TextDocument,
+} from 'vscode';
+
+import { FileLocationStore } from '@i18n-weave/store/store-file-location-store';
+
+import {
+  ConfigurationStoreManager,
+  I18nextScannerModuleConfiguration,
+} from '@i18n-weave/util/util-configuration';
+import { createI18nHoverMarkdown } from '@i18n-weave/util/util-markdown-string-utils';
+import { extractNamespaceFromTranslationKey } from '@i18n-weave/util/util-translation-key-utils';
+
+export class TranslationKeyHoverProvider implements HoverProvider {
+  private static _instance: TranslationKeyHoverProvider;
+
+  private constructor() {
+    // Private constructor to prevent instantiation
+  }
+
+  /**
+   * Returns the singleton instance of TranslationKeyHoverProvider.
+   */
+  public static getInstance(): TranslationKeyHoverProvider {
+    if (!TranslationKeyHoverProvider._instance) {
+      TranslationKeyHoverProvider._instance = new TranslationKeyHoverProvider();
+    }
+    return TranslationKeyHoverProvider._instance;
+  }
+
+  public provideHover(
+    document: TextDocument,
+    position: Position,
+    _: CancellationToken
+  ): ProviderResult<Hover> {
+    const fileLocationStore = FileLocationStore.getInstance();
+    const configuration =
+      ConfigurationStoreManager.getInstance().getConfig<I18nextScannerModuleConfiguration>(
+        'i18nextScannerModule'
+      );
+
+    const fullKey = this.getFullKeyAtPosition(document, position);
+    if (!fullKey) {
+      return null; // No key found at cursor position
+    }
+
+    const [namespace, keyWithoutNamespace] = extractNamespaceFromTranslationKey(
+      fullKey,
+      configuration.nsSeparator,
+      configuration.defaultNamespace
+    );
+
+    // Fetch translation values from file store
+    const keys = fileLocationStore.getTranslationKeys(
+      configuration.defaultLanguage,
+      namespace
+    );
+    const translationKey = keys.find(key => key === keyWithoutNamespace);
+
+    if (!translationKey) {
+      return null; // No matching translation key found
+    }
+
+    // Fetch the translation value for the detected key
+    const translationValues =
+      fileLocationStore.getTranslationValuesByNamespaceAndKey(
+        namespace,
+        translationKey
+      );
+
+    const hoverContent = createI18nHoverMarkdown(
+      translationValues,
+      configuration.defaultLanguage
+    );
+
+    return new Hover(hoverContent);
+  }
+
+  private getFullKeyAtPosition(
+    document: TextDocument,
+    position: Position
+  ): string | null {
+    const line = document.lineAt(position.line).text;
+    const beforeCursor = line.substring(0, position.character);
+    const afterCursor = line.substring(position.character);
+
+    const startQuote = beforeCursor.lastIndexOf("'") + 1;
+    const endQuote = afterCursor.indexOf("'");
+
+    if (startQuote > 0 && endQuote >= 0) {
+      return line.substring(startQuote, position.character + endQuote);
+    }
+
+    return null;
+  }
+}
+

--- a/src/libs/store/store-file-location-store/src/lib/file-location-store.ts
+++ b/src/libs/store/store-file-location-store/src/lib/file-location-store.ts
@@ -124,6 +124,42 @@ export class FileLocationStore {
     return translationFile;
   }
 
+  public getTranslationValue(
+    language: string,
+    namespace: string,
+    translationKey: string
+  ): string | undefined | null {
+    return this.getTranslationFiles()
+      .filter(
+        file => file.language === language && file.namespace === namespace
+      )
+      .map(file => file.keys[translationKey]?.value)
+      .find(value => value !== undefined);
+  }
+
+  public getTranslationValuesByNamespaceAndKey(
+    namespace: string,
+    translationKey: string
+  ): Record<string, string | undefined | null> {
+    const translationValues: Record<string, string | undefined | null> = {};
+
+    this.getTranslationFiles()
+      .filter(file => file.namespace === namespace)
+      .forEach(file => {
+        translationValues[file.language] = file.keys[translationKey]?.value;
+      });
+
+    return translationValues;
+  }
+
+  public getTranslationKeys(language: string, namespace: string): string[] {
+    return this.getTranslationFiles()
+      .filter(
+        file => file.language === language && file.namespace === namespace
+      )
+      .flatMap(file => Object.keys(file.keys));
+  }
+
   async createCodeFileAsync(uri: vscode.Uri) {
     const fileContent = await FileReader.readWorkspaceFileAsync(uri);
     const stats = fs.statSync(uri.fsPath);

--- a/src/libs/util/util-markdown-string-utils/src/index.ts
+++ b/src/libs/util/util-markdown-string-utils/src/index.ts
@@ -1,0 +1,1 @@
+export * from './lib/markdown-string-utils';

--- a/src/libs/util/util-markdown-string-utils/src/lib/markdown-string-utils.test.ts
+++ b/src/libs/util/util-markdown-string-utils/src/lib/markdown-string-utils.test.ts
@@ -1,2 +1,94 @@
+import assert from 'assert';
+import sinon from 'sinon';
+
+import { createI18nHoverMarkdown } from './markdown-string-utils';
+
 /* eslint-disable no-restricted-imports */
 // Tests for MarkdownStringUtils
+suite('createI18nHoverMarkdown', () => {
+  let sandbox: sinon.SinonSandbox;
+
+  setup(() => {
+    sandbox = sinon.createSandbox();
+  });
+
+  teardown(() => {
+    sandbox.restore();
+  });
+
+  test('should create a markdown string with correct translation progress', () => {
+    const translations = {
+      en: 'Hello',
+      fr: 'Bonjour',
+      es: 'Hola',
+      de: null,
+    };
+    const defaultLanguage = 'en';
+    const markdown = createI18nHoverMarkdown(translations, defaultLanguage);
+
+    assert(markdown.value.includes('### Translation Progress: **75%** (3/4)'));
+  });
+
+  test('should show a warning if default translation is missing', () => {
+    const translations = {
+      en: null,
+      fr: 'Bonjour',
+      es: 'Hola',
+      de: 'Hallo',
+    };
+    const defaultLanguage = 'en';
+    const markdown = createI18nHoverMarkdown(translations, defaultLanguage);
+
+    assert(markdown.value.includes('**Default translation (en) missing!**'));
+  });
+
+  test('should show language status correctly', () => {
+    const translations = {
+      en: 'Hello',
+      fr: 'Bonjour',
+      es: 'Hola',
+      de: null,
+    };
+    const defaultLanguage = 'en';
+    const markdown = createI18nHoverMarkdown(translations, defaultLanguage);
+
+    assert(markdown.value.includes('- **en:** ✔'));
+    assert(markdown.value.includes('- **de:** ✖'));
+  });
+
+  test('should show length difference warning if applicable', () => {
+    const translations = {
+      en: 'Hello',
+      fr: 'Bonjour',
+      es: 'Hola',
+      de: 'Hallo Welt',
+    };
+    const defaultLanguage = 'en';
+    const lengthDifferenceThreshold = 3;
+    const markdown = createI18nHoverMarkdown(
+      translations,
+      defaultLanguage,
+      lengthDifferenceThreshold
+    );
+
+    assert(markdown.value.includes('- **de:** ✔ ⚠ Length difference'));
+  });
+
+  test('should not show length difference warning if not applicable', () => {
+    const translations = {
+      en: 'Hello',
+      fr: 'Bonjour',
+      es: 'Hola',
+      de: 'Hallo',
+    };
+    const defaultLanguage = 'en';
+    const lengthDifferenceThreshold = 10;
+    const markdown = createI18nHoverMarkdown(
+      translations,
+      defaultLanguage,
+      lengthDifferenceThreshold
+    );
+
+    assert(!markdown.value.includes('⚠ Length difference'));
+  });
+});

--- a/src/libs/util/util-markdown-string-utils/src/lib/markdown-string-utils.test.ts
+++ b/src/libs/util/util-markdown-string-utils/src/lib/markdown-string-utils.test.ts
@@ -1,0 +1,2 @@
+/* eslint-disable no-restricted-imports */
+// Tests for MarkdownStringUtils

--- a/src/libs/util/util-markdown-string-utils/src/lib/markdown-string-utils.ts
+++ b/src/libs/util/util-markdown-string-utils/src/lib/markdown-string-utils.ts
@@ -1,0 +1,74 @@
+import vscode from 'vscode';
+
+export function createI18nHoverMarkdown(
+  translations: Record<string, string | undefined | null>,
+  defaultLanguage: string,
+  lengthDifferenceThreshold: number = 30
+): vscode.MarkdownString {
+  const markdown = new vscode.MarkdownString();
+  const languages = Object.keys(translations);
+  const translatedCount = Object.values(translations).filter(t =>
+    t?.trim()
+  ).length;
+  const defaultTranslation = translations[defaultLanguage];
+
+  markdown.appendMarkdown(
+    [
+      `### Translation Progress: **${Math.round((translatedCount / languages.length) * 100)}%** (${translatedCount}/${languages.length})`,
+      '---',
+      defaultTranslation
+        ? ''
+        : `**Default translation (${defaultLanguage}) missing!**`,
+      '---',
+      '#### Language Status:',
+      ...languages.map(lang =>
+        getLanguageStatus(
+          lang,
+          translations[lang],
+          defaultTranslation,
+          lengthDifferenceThreshold
+        )
+      ),
+      '---',
+      defaultTranslation
+        ? `#### Default translation (${defaultLanguage}):\n"${defaultTranslation}"`
+        : '',
+    ].join('\n')
+  );
+
+  markdown.isTrusted = true;
+  return markdown;
+}
+
+function getLanguageStatus(
+  lang: string,
+  translation: string | undefined | null,
+  defaultTranslation: string | undefined | null,
+  lengthDifferenceThreshold: number
+): string {
+  const hasTranslation = !!translation?.trim();
+  let warning = '';
+
+  if (hasTranslation && defaultTranslation) {
+    const sameCharSet =
+      getCharSet(translation) === getCharSet(defaultTranslation);
+    const lengthDiff = Math.abs(
+      defaultTranslation.length - (translation?.length ?? 0)
+    );
+    if (sameCharSet && lengthDiff > lengthDifferenceThreshold) {
+      warning = '⚠ Length difference';
+    }
+  }
+
+  return `- **${lang}:** ${hasTranslation ? '✔' : '✖'} ${warning}`;
+}
+
+function getCharSet(text: string | undefined | null): string {
+  if (!text) return 'unknown';
+  if (/[\p{Script=Hiragana}\p{Script=Katakana}\p{Script=Han}]/u.test(text))
+    return 'CJK';
+  if (/[A-Za-z]/u.test(text)) return 'Latin';
+  if (/[А-яЁё]/u.test(text)) return 'Cyrillic';
+  return 'other';
+}
+

--- a/src/libs/util/util-translation-key-utils/src/index.ts
+++ b/src/libs/util/util-translation-key-utils/src/index.ts
@@ -1,0 +1,1 @@
+export * from './lib/translation-key-utils';

--- a/src/libs/util/util-translation-key-utils/src/lib/translation-key-utils.test.ts
+++ b/src/libs/util/util-translation-key-utils/src/lib/translation-key-utils.test.ts
@@ -1,0 +1,2 @@
+/* eslint-disable no-restricted-imports */
+// Tests for TranslationKeyUtils

--- a/src/libs/util/util-translation-key-utils/src/lib/translation-key-utils.ts
+++ b/src/libs/util/util-translation-key-utils/src/lib/translation-key-utils.ts
@@ -1,0 +1,25 @@
+export function extractTranslationKeys(
+  text: string,
+  translationFunctionNames: string[]
+): RegExpExecArray | null {
+  const translationCallRegex = new RegExp(
+    `(${translationFunctionNames.join('|')})\\s*\\(\\s*['"]([^'"]*)$`,
+    's'
+  );
+
+  return translationCallRegex.exec(text);
+}
+
+export function extractNamespaceFromTranslationKey(
+  keyPrefix: string,
+  namespaceSeparator: string,
+  defaultNamespace: string
+): [string, string] {
+  if (keyPrefix.includes(namespaceSeparator)) {
+    const [namespace, keyWithoutNamespace] =
+      keyPrefix.split(namespaceSeparator);
+    return [namespace, keyWithoutNamespace];
+  } else {
+    return [defaultNamespace, keyPrefix];
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -145,10 +145,16 @@
       ],
       "@i18n-weave/feature/feature-translation-key-completion-provider": [
         "src/libs/feature/feature-translation-key-completion-provider/src"
-      ]//,
-      // "@i18n-weave/feature/feature-translation-definition-provider": [
-      //   "src/libs/feature/feature-translation-definition-provider/src"
-      // ]
+      ],
+      "@i18n-weave/feature/feature-translation-key-hover-provider": [
+        "src/libs/feature/feature-translation-key-hover-provider/src"
+      ],
+      "@i18n-weave/util/util-translation-key-utils": [
+        "src/libs/util/util-translation-key-utils/src"
+      ],
+      "@i18n-weave/util/util-markdown-string-utils": [
+        "src/libs/util/util-markdown-string-utils/src"
+      ]
     },
     "module": "CommonJS",
     "target": "ES2022",


### PR DESCRIPTION
### Description

This update introduces new functionality to i18nWeave, specifically enhancing the experience of developers working with translations. The primary feature added is the `TranslationKeyHoverProvider`, which offers instant hover information over translation keys within the editor. This feature is aimed at improving productivity by allowing quick access to translation values directly from the source code.

### Changes

- **Translation Key Hover Provider**: A singleton `TranslationKeyHoverProvider` has been created to show translation values when hovering over translation keys in supported languages. It fetches and displays these values from a file store.
- **Translation Utilities**: New functions have been added to extract translation keys and namespaces, thereby streamlining the translation management process.
- **Markdown Utilities for i18n**: A suite of utilities is introduced to generate markdown content, which visually displays translation progress and status across different languages. These utilities aid developers in recognizing translation states and potential issues quickly.
- **Refactoring**: Code has been refactored to integrate these new utilities for translation keys, ensuring better maintainability and consistency throughout the extension.
- **Translation Retrieval Enhancements**: The file store now includes methods for fetching individual translation values or groups by namespace or key, providing a more flexible approach to managing translation data.

### Impact

These enhancements significantly improve the internationalization development workflow within VSCode. They provide developers with more intuitive and immediate insights into translations, helping to maintain consistent and up-to-date key usage throughout their projects. By enhancing the hover functionality, developers save time and reduce errors in translation management.