### PR TITLE
fix: handle crlf and lf line endings separately

### DIFF
--- a/src/libs/module/module-translation/src/lib/translation-module.ts
+++ b/src/libs/module/module-translation/src/lib/translation-module.ts
@@ -195,7 +195,8 @@ export class TranslationModule extends BaseActionModule {
     translationsByLanguage: { [x: string]: any },
     config: GeneralConfiguration
   ) {
-    let fileShouldEndWithNewLine: boolean = false;
+    let fileShouldEndWithCrlf: boolean = false;
+    let fileShouldEndWithLf: boolean = false;
 
     for (const fileUri of targetFiles) {
       if (FileLockStore.getInstance().hasFileLock(fileUri)) {
@@ -206,7 +207,9 @@ export class TranslationModule extends BaseActionModule {
       try {
         const fileContentAsString =
           await FileReader.readWorkspaceFileAsync(fileUri);
-        fileShouldEndWithNewLine = fileContentAsString.endsWith('\n');
+        fileShouldEndWithCrlf = fileContentAsString.endsWith('\r\n');
+        fileShouldEndWithLf =
+          fileContentAsString.endsWith('\n') && !fileShouldEndWithCrlf;
 
         fileContent = JSON.parse(fileContentAsString);
       } catch (error) {
@@ -229,7 +232,10 @@ export class TranslationModule extends BaseActionModule {
           config.format.numberOfSpacesForIndentation
         );
 
-        if (fileShouldEndWithNewLine && !stringifiedContent.endsWith('\n')) {
+        if (fileShouldEndWithCrlf && !stringifiedContent.endsWith('\r\n')) {
+          stringifiedContent += '\r\n';
+        }
+        if (fileShouldEndWithLf && !stringifiedContent.endsWith('\n')) {
           stringifiedContent += '\n';
         }
 


### PR DESCRIPTION
### Description

This pull request addresses the issue of handling different line endings, specifically the distinction between CRLF and LF. The update aims to improve the consistency of file line endings by incorporating logic that identifies and applies the appropriate line ending format based on the existing content of a file.

### Changes

- Added logic to differentiate and handle CRLF and LF line endings separately.
- Updated the mechanism to determine the current line ending format used in files.
- Implemented logic to append or maintain the correct line ending format as per original file content.

### Impact

This change is expected to enhance file consistency and prevent potential issues related to mixed line endings. It should ensure that modifications to text files retain their original line ending formats, thereby improving cross-platform compatibility and reducing git diff noise related to line ending formats.

<!-- GitButler Footer Boundary Top -->
---
This is **part 2 of 2 in a stack** made with GitButler:
- <kbd>&nbsp;2&nbsp;</kbd> #246 👈 
- <kbd>&nbsp;1&nbsp;</kbd> #245 
<!-- GitButler Footer Boundary Bottom -->

