### PR TITLE
feat: add translation key definitions navigation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -53,7 +53,7 @@
         "eslint-plugin-unused-imports": "^4.1.4",
         "mock-fs": "^5.2.0",
         "prettier": "^3.3.1",
-        "sinon": "^18.0.0",
+        "sinon": "^18.0.1",
         "ts-loader": "^9.5.1",
         "tsc-alias": "^1.8.10",
         "tsconfig-paths-webpack-plugin": "^4.1.0",
@@ -2390,6 +2390,7 @@
       "resolved": "https://registry.npmjs.org/@types/sinon/-/sinon-17.0.3.tgz",
       "integrity": "sha512-j3uovdn8ewky9kRBG19bOwaZbexJu/XjtkHyjvUgt4xfPFz18dcORIMqnYh66Fx3Powhcr85NT5+er3+oViapw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@types/sinonjs__fake-timers": "*"
       }
@@ -7635,13 +7636,14 @@
       }
     },
     "node_modules/sinon": {
-      "version": "18.0.0",
-      "resolved": "https://registry.npmjs.org/sinon/-/sinon-18.0.0.tgz",
-      "integrity": "sha512-+dXDXzD1sBO6HlmZDd7mXZCR/y5ECiEiGCBSGuFD/kZ0bDTofPYc6JaeGmPSF+1j1MejGUWkORbYOLDyvqCWpA==",
+      "version": "18.0.1",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-18.0.1.tgz",
+      "integrity": "sha512-a2N2TDY1uGviajJ6r4D1CyRAkzE9NNVlYOV1wX5xQDuAk0ONgzgRl0EjCQuRCPxOwp13ghsMwt9Gdldujs39qw==",
       "dev": true,
+      "license": "BSD-3-Clause",
       "dependencies": {
         "@sinonjs/commons": "^3.0.1",
-        "@sinonjs/fake-timers": "^11.2.2",
+        "@sinonjs/fake-timers": "11.2.2",
         "@sinonjs/samsam": "^8.0.0",
         "diff": "^5.2.0",
         "nise": "^6.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
         "i18next-scanner": "^4.4.0",
         "inquirer": "^12.0.1",
         "json-stable-stringify": "^1.1.1",
+        "jsonc-parser": "^3.3.1",
         "lodash": "^4.17.21",
         "vinyl-fs": "^4.0.0"
       },
@@ -6023,6 +6024,12 @@
       "bin": {
         "json5": "lib/cli.js"
       }
+    },
+    "node_modules/jsonc-parser": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.3.1.tgz",
+      "integrity": "sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==",
+      "license": "MIT"
     },
     "node_modules/jsonify": {
       "version": "0.0.1",

--- a/package.json
+++ b/package.json
@@ -314,6 +314,7 @@
     "i18next-scanner": "^4.4.0",
     "inquirer": "^12.0.1",
     "json-stable-stringify": "^1.1.1",
+    "jsonc-parser": "^3.3.1",
     "lodash": "^4.17.21",
     "vinyl-fs": "^4.0.0"
   }

--- a/package.json
+++ b/package.json
@@ -288,7 +288,7 @@
     "eslint-plugin-unused-imports": "^4.1.4",
     "mock-fs": "^5.2.0",
     "prettier": "^3.3.1",
-    "sinon": "^18.0.0",
+    "sinon": "^18.0.1",
     "ts-loader": "^9.5.1",
     "tsc-alias": "^1.8.10",
     "tsconfig-paths-webpack-plugin": "^4.1.0",

--- a/src/core/extension.ts
+++ b/src/core/extension.ts
@@ -7,6 +7,7 @@ import { ActiveTextEditorChangedHandler } from '@i18n-weave/feature/feature-acti
 import { ConfigurationWizardService } from '@i18n-weave/feature/feature-configuration-wizard';
 import { FileLocationInitializer } from '@i18n-weave/feature/feature-file-location-initializer';
 import { FileWatcherCreator } from '@i18n-weave/feature/feature-file-watcher-creator';
+import { I18nextDefinitionProvider } from '@i18n-weave/feature/feature-i18next-definition-provider';
 import {
   StatusBarManager,
   StatusBarState,
@@ -134,7 +135,7 @@ export async function activate(
       );
     const translationKeyCompletionProvider =
       TranslationKeyCompletionProvider.getInstance();
-    const completionItemProviderDisposable =
+    const translationKeyCompletionProviderDisposable =
       vscode.languages.registerCompletionItemProvider(
         [
           { language: 'javascript', scheme: 'file' },
@@ -151,27 +152,28 @@ export async function activate(
 
     const translationKeyHoverProvider =
       TranslationKeyHoverProvider.getInstance();
-    const hoverProviderDisposable = vscode.languages.registerHoverProvider(
-      [
-        { language: 'javascript', scheme: 'file' },
-        { language: 'typescript', scheme: 'file' },
-        { language: 'javascriptreact', scheme: 'file' }, // For .jsx files
-        { language: 'typescriptreact', scheme: 'file' }, // For .tsx files
-      ],
-      translationKeyHoverProvider
-    );
+    const translationKeyHoverProviderDisposable =
+      vscode.languages.registerHoverProvider(
+        [
+          { language: 'javascript', scheme: 'file' },
+          { language: 'typescript', scheme: 'file' },
+          { language: 'javascriptreact', scheme: 'file' }, // For .jsx files
+          { language: 'typescriptreact', scheme: 'file' }, // For .tsx files
+        ],
+        translationKeyHoverProvider
+      );
 
-    // const definitionProvider = TranslationDefinitionProvider.getInstance();
-    // const translationDefinitionProviderDisposable =
-    //   vscode.languages.registerDefinitionProvider(
-    //     [
-    //       { language: 'javascript', scheme: 'file' },
-    //       { language: 'typescript', scheme: 'file' },
-    //       { language: 'javascriptreact', scheme: 'file' }, // For .jsx files
-    //       { language: 'typescriptreact', scheme: 'file' }, // For .tsx files
-    //     ],
-    //     definitionProvider
-    //   );
+    const i18nextDefinitionProvider = I18nextDefinitionProvider.getInstance();
+    const i18nextDefinitionProviderDisposable =
+      vscode.languages.registerDefinitionProvider(
+        [
+          { language: 'javascript', scheme: 'file' },
+          { language: 'typescript', scheme: 'file' },
+          { language: 'javascriptreact', scheme: 'file' }, // For .jsx files
+          { language: 'typescriptreact', scheme: 'file' }, // For .tsx files
+        ],
+        i18nextDefinitionProvider
+      );
 
     // -------------------------------------
 
@@ -182,9 +184,9 @@ export async function activate(
       onDidChangeTextDocumentDisposable,
       configurationWizardCommandDisposable,
       configurationWatcherDisposable,
-      completionItemProviderDisposable,
-      hoverProviderDisposable
-      // translationDefinitionProviderDisposable
+      translationKeyCompletionProviderDisposable,
+      translationKeyHoverProviderDisposable,
+      i18nextDefinitionProviderDisposable
     );
 
     statusBarManager.updateState(StatusBarState.Idle, 'Idle');

--- a/src/libs/feature/feature-i18next-definition-provider/src/index.ts
+++ b/src/libs/feature/feature-i18next-definition-provider/src/index.ts
@@ -1,0 +1,1 @@
+export * from './lib/i18next-definition-provider';

--- a/src/libs/feature/feature-i18next-definition-provider/src/lib/i18next-definition-provider.test.ts
+++ b/src/libs/feature/feature-i18next-definition-provider/src/lib/i18next-definition-provider.test.ts
@@ -1,2 +1,121 @@
-/* eslint-disable no-restricted-imports */
-// Tests for I18nextDefinitionProvider
+import assert from 'assert';
+import sinon from 'sinon';
+import { Location, Position, TextDocument, Uri } from 'vscode';
+
+import { FileLocationStore } from '@i18n-weave/store/store-file-location-store';
+
+import { ConfigurationStoreManager } from '@i18n-weave/util/util-configuration';
+
+import { I18nextDefinitionProvider } from './i18next-definition-provider';
+
+suite('I18nextDefinitionProvider', () => {
+  let definitionProvider: I18nextDefinitionProvider;
+  let documentStub: sinon.SinonStubbedInstance<TextDocument>;
+  let positionStub: sinon.SinonStubbedInstance<Position>;
+  let fileLocationStoreStub: sinon.SinonStubbedInstance<FileLocationStore>;
+  let configurationStoreManagerStub: sinon.SinonStubbedInstance<ConfigurationStoreManager>;
+
+  setup(() => {
+    definitionProvider = I18nextDefinitionProvider.getInstance();
+    documentStub = {
+      uri: Uri.file('/path/to/file'),
+      fileName: '/path/to/file',
+      isUntitled: false,
+      languageId: 'plaintext',
+      version: 1,
+      isDirty: false,
+      isClosed: false,
+      save: sinon.stub().resolves(true),
+      lineCount: 1,
+      lineAt: sinon.stub(),
+      offsetAt: sinon.stub(),
+      positionAt: sinon.stub(),
+      getText: sinon.stub(),
+      getWordRangeAtPosition: sinon.stub(),
+      validateRange: sinon.stub(),
+      validatePosition: sinon.stub(),
+    } as unknown as sinon.SinonStubbedInstance<TextDocument>;
+    positionStub = sinon.createStubInstance(Position);
+    fileLocationStoreStub = sinon.createStubInstance(FileLocationStore);
+    configurationStoreManagerStub = sinon.createStubInstance(
+      ConfigurationStoreManager
+    );
+
+    sinon.stub(FileLocationStore, 'getInstance').returns(fileLocationStoreStub);
+    sinon
+      .stub(ConfigurationStoreManager, 'getInstance')
+      .returns(configurationStoreManagerStub);
+  });
+
+  teardown(() => {
+    sinon.restore();
+  });
+
+  test('should return null if no full key is found at the position', async () => {
+    // @ts-ignore - stubbing private method
+    sinon.stub(definitionProvider, 'getFullKeyAtPosition').returns(null);
+
+    const result = await definitionProvider.provideDefinition(
+      documentStub,
+      positionStub
+    );
+
+    assert.equal(result, null);
+  });
+
+  test('should return null if the key is not found in the translation store', async () => {
+    sinon
+      // @ts-ignore - stubbing private method
+      .stub(definitionProvider, 'getFullKeyAtPosition')
+      // @ts-ignore - stubbing private method
+      .returns('namespace:key');
+    configurationStoreManagerStub.getConfig.returns({
+      nsSeparator: ':',
+      defaultNamespace: 'default',
+      defaultLanguage: 'en',
+    });
+    fileLocationStoreStub.getTranslationFiles.returns([]);
+
+    const result = await definitionProvider.provideDefinition(
+      documentStub,
+      positionStub
+    );
+
+    assert.equal(result, null);
+  });
+
+  test('should return the location of the key if found in the translation store', async () => {
+    const mockLocation = new Location(
+      Uri.file('/path/to/file'),
+      new Position(0, 0)
+    );
+    sinon
+      // @ts-ignore - stubbing private method
+      .stub(definitionProvider, 'getFullKeyAtPosition')
+      // @ts-ignore - stubbing private method
+      .returns('namespace:key');
+    configurationStoreManagerStub.getConfig.returns({
+      nsSeparator: ':',
+      defaultNamespace: 'default',
+      defaultLanguage: 'en',
+    });
+    fileLocationStoreStub.getTranslationFiles.returns([
+      {
+        language: 'en',
+        namespace: 'namespace',
+        keys: {
+          // @ts-ignore - ignoring missing properties
+          key: { location: mockLocation },
+        },
+      },
+    ]);
+
+    const result = await definitionProvider.provideDefinition(
+      documentStub,
+      positionStub
+    );
+
+    assert.equal(result, mockLocation);
+  });
+});
+

--- a/src/libs/feature/feature-i18next-definition-provider/src/lib/i18next-definition-provider.test.ts
+++ b/src/libs/feature/feature-i18next-definition-provider/src/lib/i18next-definition-provider.test.ts
@@ -1,0 +1,2 @@
+/* eslint-disable no-restricted-imports */
+// Tests for I18nextDefinitionProvider

--- a/src/libs/feature/feature-i18next-definition-provider/src/lib/i18next-definition-provider.ts
+++ b/src/libs/feature/feature-i18next-definition-provider/src/lib/i18next-definition-provider.ts
@@ -1,0 +1,85 @@
+import * as vscode from 'vscode';
+
+import { FileLocationStore } from '@i18n-weave/store/store-file-location-store';
+
+import {
+  ConfigurationStoreManager,
+  I18nextScannerModuleConfiguration,
+} from '@i18n-weave/util/util-configuration';
+import { extractNamespaceFromTranslationKey } from '@i18n-weave/util/util-translation-key-utils';
+
+export class I18nextDefinitionProvider implements vscode.DefinitionProvider {
+  private static _instance: I18nextDefinitionProvider;
+
+  private constructor() {
+    // Private constructor to prevent instantiation
+  }
+
+  public static getInstance(): I18nextDefinitionProvider {
+    if (!I18nextDefinitionProvider._instance) {
+      I18nextDefinitionProvider._instance = new I18nextDefinitionProvider();
+    }
+    return I18nextDefinitionProvider._instance;
+  }
+
+  public async provideDefinition(
+    document: vscode.TextDocument,
+    position: vscode.Position
+  ): Promise<vscode.Location | vscode.Location[] | null> {
+    const fileLocationStore = FileLocationStore.getInstance();
+    const configuration =
+      ConfigurationStoreManager.getInstance().getConfig<I18nextScannerModuleConfiguration>(
+        'i18nextScannerModule'
+      );
+
+    // Get the full translation key under the cursor
+    const fullKey = this.getFullKeyAtPosition(document, position);
+
+    if (!fullKey) {
+      return null;
+    }
+
+    const [namespace, keyWithoutNamespace] = extractNamespaceFromTranslationKey(
+      fullKey,
+      configuration.nsSeparator,
+      configuration.defaultNamespace
+    );
+
+    // Search for this key in the translation store
+    for (const record of fileLocationStore
+      .getTranslationFiles()
+      .filter(
+        x =>
+          x.language === configuration.defaultLanguage &&
+          x.namespace === namespace
+      )) {
+      const keyData = record.keys[keyWithoutNamespace];
+
+      if (keyData) {
+        // If we find the key, return its location
+        return keyData.location;
+      }
+    }
+
+    return null; // Key not found
+  }
+
+  private getFullKeyAtPosition(
+    document: vscode.TextDocument,
+    position: vscode.Position
+  ): string | null {
+    const line = document.lineAt(position.line).text;
+    const beforeCursor = line.substring(0, position.character);
+    const afterCursor = line.substring(position.character);
+
+    const startQuote = beforeCursor.lastIndexOf("'") + 1;
+    const endQuote = afterCursor.indexOf("'");
+
+    if (startQuote > 0 && endQuote >= 0) {
+      return line.substring(startQuote, position.character + endQuote);
+    }
+
+    return null;
+  }
+}
+

--- a/src/libs/store/store-code-translation-key-store/src/lib/code-translation-key-store.ts
+++ b/src/libs/store/store-code-translation-key-store/src/lib/code-translation-key-store.ts
@@ -3,8 +3,8 @@ import { ExtensionContext, ProgressLocation, Uri, window } from 'vscode';
 
 import { FileReader } from '@i18n-weave/file-io/file-io-file-reader';
 
+import { extractTranslationKeys } from '@i18n-weave/util/util-code-file-utils';
 import { I18nextScannerModuleConfiguration } from '@i18n-weave/util/util-configuration';
-import { extractTranslationKeys } from '@i18n-weave/util/util-i18next-ast';
 import { LogLevel, Logger } from '@i18n-weave/util/util-logger';
 
 type CodeTranslation = {

--- a/src/libs/store/store-file-location-store/src/index.ts
+++ b/src/libs/store/store-file-location-store/src/index.ts
@@ -1,1 +1,2 @@
 export * from './lib/file-location-store';
+export * from './lib/file-location-store.types';

--- a/src/libs/store/store-file-location-store/src/lib/file-location-store.ts
+++ b/src/libs/store/store-file-location-store/src/lib/file-location-store.ts
@@ -1,5 +1,5 @@
 import fs from 'fs';
-import vscode, { Uri } from 'vscode';
+import vscode from 'vscode';
 
 import { FileReader } from '@i18n-weave/file-io/file-io-file-reader';
 
@@ -13,14 +13,11 @@ import {
   extractNamespaceFromFileUri,
   getFileExtension,
 } from '@i18n-weave/util/util-file-path-utilities';
+import { extractTranslationKeys } from '@i18n-weave/util/util-i18next-file-utils';
 import { LogLevel, Logger } from '@i18n-weave/util/util-logger';
 import { FileSearchLocation } from '@i18n-weave/util/util-types';
 
-import {
-  CodeFile,
-  TranslationFile,
-  TranslationKeyData,
-} from './file-location-store.types';
+import { CodeFile, TranslationFile } from './file-location-store.types';
 
 export class FileLocationStore {
   private readonly _className = 'FileLocationStore';
@@ -107,7 +104,7 @@ export class FileLocationStore {
     const namespace = extractNamespaceFromFileUri(uri);
     const stats = fs.statSync(uri.fsPath);
     const lastModified = stats.mtime;
-    const keys = await this.extractTranslationKeys(uri);
+    const keys = await extractTranslationKeys(uri);
 
     const translationFile = {
       content: fileContent,
@@ -222,93 +219,5 @@ export class FileLocationStore {
       this._className
     );
     throw new Error(`Unsupported file type: ${extension}`);
-  }
-
-  // extract below to util
-
-  /**
-   * Extracts translation keys, values, and their locations from a JSON resource file.
-   * @param filePath - The path to the JSON resource file.
-   * @returns A map of keys to their corresponding TranslationKeyData.
-   */
-  private async extractTranslationKeys(
-    fileUri: Uri
-  ): Promise<Record<string, TranslationKeyData>> {
-    const content = await new FileReader().readWorkspaceFileAsync(fileUri);
-    const json = JSON.parse(content);
-
-    const keysData: Record<string, TranslationKeyData> = {};
-
-    // Recursively traverse the JSON object to find keys and track their locations
-    await this.traverseJsonObject(json, fileUri, [], keysData);
-
-    return keysData;
-  }
-
-  /**
-   * Traverses a JSON object recursively and records the locations of each translation key.
-   * @param obj - The JSON object being traversed.
-   * @param filePath - The path to the file, for location context.
-   * @param parentKeys - Array of parent keys leading to the current key.
-   * @param keysData - The map to store the key data.
-   */
-  private async traverseJsonObject(
-    obj: any,
-    fileUri: Uri,
-    parentKeys: string[],
-    keysData: Record<string, TranslationKeyData>
-  ): Promise<void> {
-    if (typeof obj === 'object' && obj !== null) {
-      // If it's an object, recurse through the keys
-      for (const key of Object.keys(obj)) {
-        const newParentKeys = [...parentKeys, key];
-
-        // Recursively traverse deeper if the value is an object
-        this.traverseJsonObject(obj[key], fileUri, newParentKeys, keysData);
-      }
-    } else {
-      // If it's a primitive (string, number, etc.), we've reached a translation key
-      const fullKey = parentKeys.join('.');
-      const location = await this.getLocationForKey(fileUri, fullKey);
-
-      keysData[fullKey] = {
-        value: obj,
-        location: location,
-      };
-    }
-  }
-
-  /**
-   * Finds the location of a translation key in the source code.
-   * This function will simulate how you might map the key to a location in the code.
-   * You can use `vscode.Position` to create locations, depending on your use case.
-   * @param filePath - The path to the resource file.
-   * @param key - The translation key.
-   * @returns A vscode.Location representing the position of the key in the file.
-   */
-  private async getLocationForKey(
-    fileUri: Uri,
-    _: string
-    // key: string
-  ): Promise<vscode.Location> {
-    // For the sake of this example, assume the location is at the first line, and the key is at the start of the line
-    const position = new vscode.Position(0, 0); // Adjust this logic based on how you locate the key in the file
-    // const document = await vscode.workspace.openTextDocument(fileUri.fsPath);
-    // const text = document.getText();
-    // const regex = new RegExp(`"${key}"\\s*:\\s*`, 'g');
-    // let match;
-    // let position = new vscode.Position(14, 20);
-
-    // while ((match = regex.exec(text)) !== null) {
-    //   const startIndex = match.index;
-    //   position = document.positionAt(startIndex);
-    //   // Return the first match found
-    //   return new vscode.Location(document.uri, position);
-    // }
-
-    // Simulate the location based on the key and file
-    const document = await vscode.workspace.openTextDocument(fileUri.fsPath); // Load document for location details
-    // If no match is found, return the default position
-    return new vscode.Location(document.uri, position);
   }
 }

--- a/src/libs/util/util-code-file-utils/src/index.ts
+++ b/src/libs/util/util-code-file-utils/src/index.ts
@@ -1,0 +1,1 @@
+export * from './lib/code-file-utils';

--- a/src/libs/util/util-code-file-utils/src/lib/code-file-utils.test.ts
+++ b/src/libs/util/util-code-file-utils/src/lib/code-file-utils.test.ts
@@ -8,7 +8,7 @@ import {
 } from '@i18n-weave/util/util-configuration';
 import { LogLevel, Logger } from '@i18n-weave/util/util-logger';
 
-import { extractTranslationKeys } from './i18next-ast';
+import { extractTranslationKeys } from './code-file-utils';
 
 suite('I18nextAst', () => {
   const extensionName = 'qvotaxon.i18nWeave';
@@ -104,3 +104,4 @@ suite('I18nextAst', () => {
     logSpy.restore();
   });
 });
+

--- a/src/libs/util/util-code-file-utils/src/lib/code-file-utils.ts
+++ b/src/libs/util/util-code-file-utils/src/lib/code-file-utils.ts
@@ -86,3 +86,4 @@ export function extractTranslationKeys(
 
   return keys;
 }
+

--- a/src/libs/util/util-i18next-ast/src/index.ts
+++ b/src/libs/util/util-i18next-ast/src/index.ts
@@ -1,1 +1,0 @@
-export * from './lib/i18next-ast';

--- a/src/libs/util/util-i18next-file-utils/src/index.ts
+++ b/src/libs/util/util-i18next-file-utils/src/index.ts
@@ -1,0 +1,1 @@
+export * from './lib/i18next-file-utils';

--- a/src/libs/util/util-i18next-file-utils/src/lib/i18next-file-utils.test.ts
+++ b/src/libs/util/util-i18next-file-utils/src/lib/i18next-file-utils.test.ts
@@ -1,0 +1,2 @@
+/* eslint-disable no-restricted-imports */
+// Tests for I18nextFileUtils

--- a/src/libs/util/util-i18next-file-utils/src/lib/i18next-file-utils.test.ts
+++ b/src/libs/util/util-i18next-file-utils/src/lib/i18next-file-utils.test.ts
@@ -1,2 +1,85 @@
+import * as sinon from 'sinon';
+import assert from 'assert';
+import { Location, Range, Uri, workspace } from 'vscode';
+
+import { extractTranslationKeys } from './i18next-file-utils';
+
 /* eslint-disable no-restricted-imports */
 // Tests for I18nextFileUtils
+suite('extractTranslationKeys', () => {
+  let openTextDocumentStub: sinon.SinonStub;
+
+  setup(() => {
+    openTextDocumentStub = sinon.stub(workspace, 'openTextDocument');
+  });
+
+  teardown(() => {
+    sinon.restore();
+  });
+
+  test('should return an empty object if the JSON is invalid', async () => {
+    openTextDocumentStub.resolves({
+      getText: () => 'invalid json',
+      uri: Uri.file('test.json'),
+    });
+
+    const result = await extractTranslationKeys(Uri.file('test.json'));
+    assert.deepEqual(result, {});
+  });
+
+  test('should extract translation keys and their locations from a valid JSON file', async () => {
+    const jsonContent = `
+    {
+      "key1": "value1",
+      "nested": {
+        "key2": "value2"
+      }
+    }`;
+
+    openTextDocumentStub.resolves({
+      getText: () => jsonContent,
+      uri: Uri.file('test.json'),
+      positionAt: (offset: number) => {
+        const lines = jsonContent.slice(0, offset).split('\n');
+        return {
+          line: lines.length - 1,
+          character: lines[lines.length - 1].length,
+        };
+      },
+    });
+
+    const result = await extractTranslationKeys(Uri.file('test.json'));
+
+    assert.deepEqual(result, {
+      key1: {
+        value: 'value1',
+        location: new Location(
+          Uri.file('test.json'),
+          // @ts-ignore - ignoring missing properties
+          new Range({ line: 2, character: 14 }, { line: 2, character: 22 })
+        ),
+      },
+      'nested.key2': {
+        value: 'value2',
+        location: new Location(
+          Uri.file('test.json'),
+          // @ts-ignore - ignoring missing properties
+          new Range({ line: 4, character: 16 }, { line: 4, character: 24 })
+        ),
+      },
+    });
+  });
+
+  test('should handle empty objects gracefully', async () => {
+    const jsonContent = `{}`;
+
+    openTextDocumentStub.resolves({
+      getText: () => jsonContent,
+      uri: Uri.file('test.json'),
+    });
+
+    const result = await extractTranslationKeys(Uri.file('test.json'));
+    assert.deepEqual(result, {});
+  });
+});
+

--- a/src/libs/util/util-i18next-file-utils/src/lib/i18next-file-utils.ts
+++ b/src/libs/util/util-i18next-file-utils/src/lib/i18next-file-utils.ts
@@ -1,0 +1,60 @@
+import { Node, parseTree } from 'jsonc-parser';
+import { Location, Range, Uri, workspace } from 'vscode';
+
+import { type TranslationKeyData } from '@i18n-weave/store/store-file-location-store';
+
+/**
+ * Extracts translation keys and their locations from an i18next JSON file.
+ * @param fileUri The vscode.Uri pointing to the JSON file.
+ * @returns A record of translation keys and their corresponding data.
+ */
+export async function extractTranslationKeys(
+  fileUri: Uri
+): Promise<Record<string, TranslationKeyData>> {
+  const document = await workspace.openTextDocument(fileUri.fsPath);
+  const text = document.getText();
+  const rootNode = parseTree(text);
+
+  if (!rootNode) {
+    return {};
+  }
+
+  const keysData: Record<string, TranslationKeyData> = {};
+
+  const processNode = (node: Node, path: string[] = []) => {
+    if (node.type === 'object') {
+      for (const property of node.children || []) {
+        const keyNode = property.children?.[0];
+        const valueNode = property.children?.[1];
+
+        if (keyNode?.value) {
+          const keyPath = [...path, keyNode.value];
+          const fullKey = keyPath.join('.'); // Join path to form dot-separated key
+
+          if (valueNode && valueNode.type !== 'object') {
+            const location = new Location(
+              document.uri,
+              new Range(
+                document.positionAt(valueNode.offset),
+                document.positionAt(valueNode.offset + valueNode.length)
+              )
+            );
+
+            keysData[fullKey] = {
+              value: valueNode.value as string | null,
+              location: location,
+            };
+          }
+
+          // Recurse into nested objects
+          if (valueNode?.type === 'object') {
+            processNode(valueNode, keyPath);
+          }
+        }
+      }
+    }
+  };
+
+  processNode(rootNode);
+  return keysData;
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,9 +2,7 @@
   "compilerOptions": {
     "baseUrl": "./",
     "paths": {
-      "@i18n-weave/core/*": [
-        "src/core/*"
-      ],
+      "@i18n-weave/core/*": ["src/core/*"],
       "@i18n-weave/feature/feature-active-text-editor-changed-handler": [
         "src/libs/feature/feature-active-text-editor-changed-handler/src"
       ],
@@ -65,9 +63,7 @@
       "@i18n-weave/file-io/file-io-file-writer": [
         "src/libs/file-io/file-io-file-writer/src"
       ],
-      "@i18n-weave/http/*": [
-        "src/libs/http/http-*/src/"
-      ],
+      "@i18n-weave/http/*": ["src/libs/http/http-*/src/"],
       "@i18n-weave/http/http-deepl-client": [
         "src/libs/http/http-deepl-client/src/"
       ],
@@ -101,15 +97,11 @@
       "@i18n-weave/util/util-configuration": [
         "src/libs/util/util-configuration/src"
       ],
-      "@i18n-weave/util/util-decorators": [
-        "src/libs/util/util-decorators/src"
-      ],
+      "@i18n-weave/util/util-decorators": ["src/libs/util/util-decorators/src"],
       "@i18n-weave/util/util-environment-utilities": [
         "src/libs/util/util-environment-utilities/src"
       ],
-      "@i18n-weave/util/util-enums": [
-        "src/libs/util/util-enums/src"
-      ],
+      "@i18n-weave/util/util-enums": ["src/libs/util/util-enums/src"],
       "@i18n-weave/util/util-file-path-utilities": [
         "src/libs/util/util-file-path-utilities/src/"
       ],
@@ -119,29 +111,20 @@
       "@i18n-weave/util/util-localization-utilities": [
         "src/libs/util/util-localization-utilities/src"
       ],
-      "@i18n-weave/util/util-logger": [
-        "src/libs/util/util-logger/src"
-      ],
+      "@i18n-weave/util/util-logger": ["src/libs/util/util-logger/src"],
       "@i18n-weave/util/util-prompt-utilities": [
         "src/libs/util/util-prompt-utilities/src"
       ],
-      "@i18n-weave/util/util-types": [
-        "src/libs/util/util-types/src"
-      ],
+      "@i18n-weave/util/util-types": ["src/libs/util/util-types/src"],
       "@i18n-weave/feature/feature-file-location-initializer": [
         "src/libs/feature/feature-file-location-initializer/src"
       ],
       "@i18n-weave/store/store-translation-store": [
         "src/libs/store/store-translation-store/src"
       ],
-      "@i18n-weave/util/util-file-diff": [
-        "src/libs/util/util-file-diff/src"
-      ],
+      "@i18n-weave/util/util-file-diff": ["src/libs/util/util-file-diff/src"],
       "@i18n-weave/util/util-nested-object-utils": [
         "src/libs/util/util-nested-object-utils/src"
-      ],
-      "@i18n-weave/util/util-i18next-ast": [
-        "src/libs/util/util-i18next-ast/src"
       ],
       "@i18n-weave/feature/feature-translation-key-completion-provider": [
         "src/libs/feature/feature-translation-key-completion-provider/src"
@@ -154,14 +137,21 @@
       ],
       "@i18n-weave/util/util-markdown-string-utils": [
         "src/libs/util/util-markdown-string-utils/src"
+      ],
+      "@i18n-weave/feature/feature-i18next-definition-provider": [
+        "src/libs/feature/feature-i18next-definition-provider/src"
+      ],
+      "@i18n-weave/util/util-code-file-utils": [
+        "src/libs/util/util-code-file-utils/src"
+      ],
+      "@i18n-weave/util/util-i18next-file-utils": [
+        "src/libs/util/util-i18next-file-utils/src"
       ]
     },
     "module": "CommonJS",
     "target": "ES2022",
     "outDir": "out",
-    "lib": [
-      "ES2022"
-    ],
+    "lib": ["ES2022"],
     "sourceMap": true,
     "rootDir": "src",
     "strict": true,
@@ -175,3 +165,4 @@
     "noUnusedParameters": true
   }
 }
+


### PR DESCRIPTION
### Description

This pull request introduces a new feature that enhances the internationalization (i18n) development workflow by providing navigation support to translation key definitions. This feature is instrumental for developers working with translations in their projects, allowing for easier management and discovery of localization keys.

### Changes

- Implemented a singleton `I18nextDefinitionProvider` that enables navigation to translation key definitions within supported files.
- Registered the `I18nextDefinitionProvider` to extend its functionality to JavaScript, TypeScript, JavaScript React, and TypeScript React files.
- Refactored variable names across the codebase to ensure consistency and clarity, making the code easier to read and maintain.

### Impact

The addition of the `I18nextDefinitionProvider` significantly improves the developer experience by streamlining access to translation keys, thereby facilitating quicker edits and accuracy in translations. This enhancement is particularly beneficial for projects with extensive use of i18n libraries, as it reduces the cognitive load on developers and aids in maintaining the correct usage of translation keys across different parts of the application.