### PR TITLE
chore: add prerelease handling to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,7 @@ name: Release
 on:
   workflow_run:
     workflows: ['Build & Test']
-    branches: [main, 'release/**']
+    branches: [main]
     types:
       - completed
 
@@ -36,6 +36,20 @@ jobs:
           token: ${{ secrets.RELEASE_PLEASE_KEY }}
           release-type: node
 
+      - name: Set prerelease flag
+        id: prerelease
+        run: |
+          echo "IS_PRERELEASE=${{ steps.release.outputs.pr != '' }}" >> $GITHUB_OUTPUT
+
+      - name: Set version
+        id: version
+        run: |
+          VERSION=${{ steps.release.outputs.tag_name }}
+          if [ "${{ steps.prerelease.outputs.IS_PRERELEASE }}" == "true" ]; then
+            VERSION="${VERSION}-pre"
+          fi
+          echo "VERSION=${VERSION}" >> $GITHUB_OUTPUT
+
       - name: Create npm dependencies directory
         run: mkdir -p .npm
 
@@ -52,39 +66,46 @@ jobs:
         # if: ${{ steps.release.outputs.release_created }}
         run: npm install
 
+      - name: Update package.json version
+        # if: ${{ steps.release.outputs.release_created }}
+        run: |
+          npm version ${{ steps.version.outputs.VERSION }} --no-git-tag-version
+
       - name: Create extension package
         # if: ${{ steps.release.outputs.release_created }}
-        run: npx vsce package -o i18nWeave-vscode-${{ steps.release.outputs.tag_name }}${{ startsWith(github.event.workflow_run.head_branch, 'release/') && '--pre-release' || '' }}.vsix
+        run: npx vsce package -o i18nWeave-vscode-${{ steps.version.outputs.VERSION }}.vsix
 
       - name: Upload Release Artifact to GitHub
         # if: ${{ steps.release.outputs.release_created }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh release upload i18nWeave-vscode-${{ steps.release.outputs.tag_name }}${{ startsWith(github.event.workflow_run.head_branch, 'release/') && '--pre-release' || '' }} i18nWeave-vscode-${{ steps.release.outputs.tag_name }}${{ startsWith(github.event.workflow_run.head_branch, 'release/') && '--pre-release' || '' }}.vsix
+        run: |
+          gh release upload ${{ steps.release.outputs.tag_name }} i18nWeave-vscode-${{ steps.version.outputs.VERSION }}.vsix
+          gh release edit ${{ steps.release.outputs.tag_name }} --prerelease=${{ steps.prerelease.outputs.IS_PRERELEASE }}
 
       - name: Publish VS Code Extension
-        # if: ${{ steps.release.outputs.release_created }}
+        if: ${{ steps.release.outputs.release_created }}
         uses: HaaLeo/publish-vscode-extension@v1.6.2
         with:
           pat: ${{ secrets.VSCE_PAT }}
           registryUrl: https://marketplace.visualstudio.com
-          preRelease: ${{ startsWith(github.event.workflow_run.head_branch, 'release/') }}
+          preRelease: ${{ steps.prerelease.outputs.IS_PRERELEASE }}
 
       - name: Create Sentry release
-        if: ${{ steps.release.outputs.release_created }}
+        # if: ${{ steps.release.outputs.release_created }}
         uses: getsentry/action-release@v1
         env:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
           SENTRY_ORG: i18nweave
           SENTRY_PROJECT: i18nweave-vscode-r3
         with:
-          version: ${{ steps.release.outputs.tag_name }}${{ startsWith(github.event.workflow_run.head_branch, 'release/') && '--pre-release' || '' }}
+          version: ${{ steps.version.outputs.VERSION }}
 
       - name: Attest Build Provenance
-        if: ${{ steps.release.outputs.release_created }}
+        # if: ${{ steps.release.outputs.release_created }}
         uses: actions/attest-build-provenance@v1.3.1
         with:
-          subject-path: i18nWeave-vscode-${{ steps.release.outputs.tag_name }}${{ startsWith(github.event.workflow_run.head_branch, 'release/') && '--pre-release' || '' }}.vsix
+          subject-path: i18nWeave-vscode-${{ steps.version.outputs.VERSION }}.vsix
 
     #   - name: Generate SBOM
     #     if: ${{ steps.release.outputs.release_created }}


### PR DESCRIPTION
### Description
This pull request enhances the existing release workflow by incorporating prerelease handling. It introduces changes to automate the tagging of prerelease versions, which allows greater flexibility in managing and deploying prerelease features.

### Changes
- Added a new step for handling prerelease version tagging in the release workflow.
- Updated npm packaging and versioning steps to consider specified prerelease versions.
- Refactored the workflow to incorporate the prerelease flag, ensuring conditional publishing and artifact uploads are executed correctly.
- Removed support for execution on 'release/**' branches to maintain focus on the main branch.

### Impact
The modifications improve the release automation process by enabling better version management for prereleases, thus enhancing the workflow's consistency and efficiency. It limits releases to the main branch, reducing the likelihood of unintended releases from development branches.