### PR TITLE
ci: update build conditions for PR and commit msg

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,9 @@ permissions:
 jobs:
   build:
     name: Build & Test
-    if: ${{ !contains(github.event.pull_request.title, 'ci') && !contains(github.event.pull_request.title, 'docs') && !contains(github.event.pull_request.title, 'doc') }}
+    if:
+      ${{ !contains(github.event.pull_request.title, 'ci') && !contains(github.event.pull_request.title, 'docs') && !contains(github.event.pull_request.title, 'doc') }} ||
+      ${{ !contains(github.event.head_commit.message, 'ci') && !contains(github.event.head_commit.message, 'docs') && !contains(github.event.head_commit.message, 'doc') }}
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
### Description

This pull request updates the continuous integration (CI) build conditions to include checks against both the pull request title and the head commit message. Previously, the build was only contingent on the PR title. This enhancement aims to ensure consistent behavior by preventing builds from triggering when the commit messages contain certain prefixes such as 'ci', 'docs', or 'doc', similar to the existing PR title checks.

### Changes

- Expanded the existing build condition logic to incorporate checks on the head commit message.
- Updated the CI configuration to enforce these additional checks, ensuring that no builds are initiated for commits meant for non-functional changes, such as updates to CI configuration or documentation.

### Impact

This change ensures that unnecessary builds are avoided, optimizing resource usage in the CI pipeline. By aligning the conditions for both PR titles and commit messages, we maintain consistency and prevent inadvertent CI runs for non-essential changes. This will help speed up the development process by reducing the time spent on running builds that don't need to be executed.