### PR TITLE
fix(workflow): trigger actions for prereleases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,7 +54,7 @@ jobs:
         run: mkdir -p .npm
 
       - name: Cache npm dependencies
-        if: ${{ steps.release.outputs.release_created }}
+        if: ${{ steps.release.outputs.release_created || steps.prerelease.outputs.IS_PRERELEASE == 'true' }}
         uses: actions/cache@v4
         with:
           path: .npm/
@@ -63,20 +63,20 @@ jobs:
             node-modules-
 
       - name: Install dependencies
-        if: ${{ steps.release.outputs.release_created }}
+        if: ${{ steps.release.outputs.release_created || steps.prerelease.outputs.IS_PRERELEASE == 'true' }}
         run: npm install
 
       - name: Update package.json version
-        if: ${{ steps.release.outputs.release_created }}
+        if: ${{ steps.release.outputs.release_created || steps.prerelease.outputs.IS_PRERELEASE == 'true' }}
         run: |
           npm version ${{ steps.version.outputs.VERSION }} --no-git-tag-version
 
       - name: Create extension package
-        if: ${{ steps.release.outputs.release_created }}
+        if: ${{ steps.release.outputs.release_created || steps.prerelease.outputs.IS_PRERELEASE == 'true' }}
         run: npx vsce package -o i18nWeave-vscode-${{ steps.version.outputs.VERSION }}.vsix
 
       - name: Upload Release Artifact to GitHub
-        if: ${{ steps.release.outputs.release_created }}
+        if: ${{ steps.release.outputs.release_created || steps.prerelease.outputs.IS_PRERELEASE == 'true' }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
@@ -84,7 +84,7 @@ jobs:
           gh release edit ${{ steps.release.outputs.tag_name }} --prerelease=${{ steps.prerelease.outputs.IS_PRERELEASE }}
 
       - name: Publish VS Code Extension
-        if: ${{ steps.release.outputs.release_created }}
+        if: ${{ steps.release.outputs.release_created || steps.prerelease.outputs.IS_PRERELEASE == 'true' }}
         uses: HaaLeo/publish-vscode-extension@v1.6.2
         with:
           pat: ${{ secrets.VSCE_PAT }}
@@ -92,7 +92,7 @@ jobs:
           preRelease: ${{ steps.prerelease.outputs.IS_PRERELEASE }}
 
       - name: Create Sentry release
-        if: ${{ steps.release.outputs.release_created }}
+        if: ${{ steps.release.outputs.release_created || steps.prerelease.outputs.IS_PRERELEASE == 'true' }}
         uses: getsentry/action-release@v1
         env:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
@@ -102,13 +102,13 @@ jobs:
           version: ${{ steps.version.outputs.VERSION }}
 
       - name: Attest Build Provenance
-        if: ${{ steps.release.outputs.release_created }}
+        if: ${{ steps.release.outputs.release_created || steps.prerelease.outputs.IS_PRERELEASE == 'true' }}
         uses: actions/attest-build-provenance@v1.3.1
         with:
           subject-path: i18nWeave-vscode-${{ steps.version.outputs.VERSION }}.vsix
 
     #   - name: Generate SBOM
-    #     if: ${{ steps.release.outputs.release_created }}
+    #     if: ${{ steps.release.outputs.release_created || steps.prerelease.outputs.IS_PRERELEASE == 'true' }}
     #     uses: anchore/sbom-action@v0
     #     with:
     #       path: 'out'
@@ -116,7 +116,7 @@ jobs:
     #       output-file: 'sbom.spdx.json'
 
     #   - name: Attest SBOM
-    #     if: ${{ steps.release.outputs.release_created }}
+    #     if: ${{ steps.release.outputs.release_created || steps.prerelease.outputs.IS_PRERELEASE == 'true' }}
     #     uses: actions/attest-sbom@v1
     #     with:
     #       subject-path: '${{ github.workspace }}/out'


### PR DESCRIPTION
### Description
This pull request addresses an issue in our GitHub Actions workflow where actions were not being triggered for prereleases. It ensures that the workflows now correctly recognize and execute necessary actions for prerelease versions, enhancing our CI/CD pipeline's flexibility and reliability.

### Changes
- Modified the GitHub Actions workflow configuration to include conditions that trigger workflows for prerelease tags.

### Impact
This change allows our CI/CD pipeline to handle prerelease versions correctly, enabling developers to efficiently test and deploy in various phases of the release cycle. There are no anticipated negative impacts on the existing workflows for stable releases. This enhancement improves our development process by supporting better early-stage testing and validation before final releases.