### PR TITLE
fix: update translation key store earlier

### DIFF
--- a/src/core/extension.ts
+++ b/src/core/extension.ts
@@ -41,13 +41,9 @@ function initializeSentry() {
     publisherExtensionName
   )!;
   const installationId = vscode.env.machineId;
-  console.log('installationId', installationId);
 
   Sentry.init({
-    enabled:
-      isProduction() &&
-      process.env.SENTRY_ENABLED === 'true' &&
-      vscode.env.isTelemetryEnabled,
+    enabled: isProduction() && vscode.env.isTelemetryEnabled,
     dsn: 'https://188de1d08857e4d1a5e59d8a9da5da1a@o4507423909216256.ingest.de.sentry.io/4507431475019856',
     integrations: Sentry.getDefaultIntegrations({}),
     tracesSampleRate: 1.0,

--- a/src/libs/feature/feature-json-file-change-handler/src/lib/json-file-change-handler.ts
+++ b/src/libs/feature/feature-json-file-change-handler/src/lib/json-file-change-handler.ts
@@ -11,6 +11,7 @@ import { BaseFileChangeHandler } from '@i18n-weave/feature/feature-base-file-cha
 import { FileWatcherCreator } from '@i18n-weave/feature/feature-file-watcher-creator';
 import { ModuleChainManager } from '@i18n-weave/feature/feature-module-chain-manager';
 
+import { FileLocationStore } from '@i18n-weave/store/store-file-location-store';
 import { FileLockStore } from '@i18n-weave/store/store-file-lock-store';
 
 import { TraceMethod } from '@i18n-weave/util/util-decorators';
@@ -84,10 +85,13 @@ export class JsonFileChangeHandler extends BaseFileChangeHandler {
   ): Promise<void> {
     await new Promise(resolve => setTimeout(resolve, 500));
 
-    if (
-      !changeFileLocation ||
-      FileLockStore.getInstance().hasFileLock(changeFileLocation)
-    ) {
+    if (!changeFileLocation) {
+      return Promise.resolve();
+    }
+
+    await FileLocationStore.getInstance().addOrUpdateFile(changeFileLocation);
+
+    if (FileLockStore.getInstance().hasFileLock(changeFileLocation)) {
       return Promise.resolve();
     }
 


### PR DESCRIPTION
### Description

This pull request addresses an issue where the translation key store was not being updated in a timely manner, resulting in discrepancies when checking for required translations. The adjustment ensures that new translation keys are added and any obsolete keys are removed before further translation checks, maintaining synchronization with the latest changes.

### Changes

- Updated the translation key store process so that it occurs earlier in the translation check flow. This modification ensures that all translation keys are current, allowing for accurate detection of required translations.

### Impact

By ensuring the translation key store is updated before validation checks, this change improves the consistency and reliability of translation management. It prevents potential issues where translations might be missed due to an outdated key set, enhancing the overall internationalization (i18n) workflow.