### PR TITLE
fix(core): use correct release format in Sentry init

### DIFF
--- a/src/core/extension.ts
+++ b/src/core/extension.ts
@@ -48,7 +48,7 @@ function initializeSentry() {
     integrations: Sentry.getDefaultIntegrations({}),
     tracesSampleRate: 1.0,
     profilesSampleRate: 1.0,
-    release: i18nWeaveExtension.packageJSON.version,
+    release: `v${i18nWeaveExtension.packageJSON.version}`,
     beforeSend(event) {
       if (
         event.exception?.values?.some(value =>


### PR DESCRIPTION
### Description

This pull request addresses an issue in the Sentry initialization process where the release format was not specified correctly. Previously, the release parameter was simply a version number, which did not align with Sentry's expected format. This misalignment could lead to difficulties in tracking releases and troubleshooting issues effectively within Sentry.

### Changes

- Updated the release parameter in the Sentry initialization from a numeric version number to a string prefixed with 'v'. This change ensures that the release format is consistent with Sentry's requirements, facilitating accurate version tracking and improving the overall observability of the application.

### Impact

This change improves the integration between our application and Sentry by ensuring the release information is reported correctly. Users should experience more reliable issue tracking and version management within Sentry, which will be especially beneficial for debugging and monitoring purposes. There should be no adverse effects on existing functionality as this update solely pertains to the format of the release information.