### PR TITLE
fix: trigger translations on change

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,10 +58,15 @@
         "id": "translationModule",
         "title": "Translation Module",
         "properties": {
+          "i18nWeave.translationModule.enabled": {
+            "type": "boolean",
+            "default": true,
+            "description": "Enable the translation module."
+          },
           "i18nWeave.translationModule.googleTranslate.enabled": {
             "type": "boolean",
             "default": "",
-            "description": "Enable translation using DeepL."
+            "description": "Enable translation using googleTranslate."
           },
           "i18nWeave.translationModule.deepL.enabled": {
             "type": "boolean",

--- a/src/core/extension.test.ts
+++ b/src/core/extension.test.ts
@@ -25,7 +25,13 @@ suite('Extension Activation', () => {
   setup(() => {
     ConfigurationStoreManager.getInstance().initialize(extensionName);
 
-    context = { subscriptions: [] } as any;
+    context = {
+      subscriptions: [],
+      globalState: {
+        get: sinon.stub(),
+        update: sinon.stub(),
+      },
+    } as any;
     fileWatcherCreator = sinon.createStubInstance(FileWatcherCreator);
     configurationStoreManagerStub = sinon
       .stub(ConfigurationStoreManager, 'getInstance')

--- a/src/libs/feature/feature-base-file-change-handler/src/lib/base-file-change-handler.ts
+++ b/src/libs/feature/feature-base-file-change-handler/src/lib/base-file-change-handler.ts
@@ -13,7 +13,7 @@ export abstract class BaseFileChangeHandler {
     TranslationStore.getInstance().deleteEntry(changeFileLocation);
   }
   public async handleFileCreationAsync(changeFileLocation: Uri): Promise<void> {
-    FileStore.getInstance().addOrUpdateFile(changeFileLocation);
+    FileStore.getInstance().addOrUpdateFileAsync(changeFileLocation);
     await TranslationStore.getInstance().addEntryAsync(changeFileLocation);
   }
 }

--- a/src/libs/feature/feature-file-watcher-creator/src/lib/file-watcher-creator.test.ts
+++ b/src/libs/feature/feature-file-watcher-creator/src/lib/file-watcher-creator.test.ts
@@ -106,7 +106,7 @@ suite('FileWatcherCreator', () => {
       createFileSystemWatcherStub.returns(mockFileWatcher);
       hasFileLockStub.returns(false);
 
-      FileStore.getInstance().addOrUpdateFile(mockUri);
+      FileStore.getInstance().addOrUpdateFileAsync(mockUri);
 
       await fileWatcherCreator.createFileWatchersForFileTypeAsync(
         FileType.Code,

--- a/src/libs/feature/feature-json-file-change-handler/src/lib/json-file-change-handler.ts
+++ b/src/libs/feature/feature-json-file-change-handler/src/lib/json-file-change-handler.ts
@@ -12,8 +12,8 @@ import { FileWatcherCreator } from '@i18n-weave/feature/feature-file-watcher-cre
 import { ModuleChainManager } from '@i18n-weave/feature/feature-module-chain-manager';
 
 import { FileLockStore } from '@i18n-weave/store/store-file-lock-store';
-import { FileStore } from '@i18n-weave/store/store-file-store';
 
+// import { FileStore } from '@i18n-weave/store/store-file-store';
 import { TraceMethod } from '@i18n-weave/util/util-decorators';
 import { ChainType } from '@i18n-weave/util/util-enums';
 import { extractFileUriParts } from '@i18n-weave/util/util-file-path-utilities';
@@ -89,7 +89,7 @@ export class JsonFileChangeHandler extends BaseFileChangeHandler {
       return Promise.resolve();
     }
 
-    await FileStore.getInstance().addOrUpdateFile(changeFileLocation);
+    // await FileStore.getInstance().addOrUpdateFileAsync(changeFileLocation);
 
     if (FileLockStore.getInstance().hasFileLock(changeFileLocation)) {
       return Promise.resolve();

--- a/src/libs/feature/feature-status-bar-manager/src/lib/status-bar-manager.test.ts
+++ b/src/libs/feature/feature-status-bar-manager/src/lib/status-bar-manager.test.ts
@@ -58,7 +58,7 @@ suite('StatusBarManager', () => {
   //   suite('updateState', () => {
   //     test('should update the status bar item state and tooltip', () => {
   //       const state = StatusBarState.Idle;
-  //       const tooltip = 'Idle';
+  //       const tooltip = 'Idle - Click to pause';
   //       statusBarManager.updateState(state, tooltip);
   //       assert.strictEqual(statusBarManager['statusBarItem'].text, `$(idle)`);
   //       assert.strictEqual(

--- a/src/libs/feature/feature-status-bar-manager/src/lib/status-bar-manager.ts
+++ b/src/libs/feature/feature-status-bar-manager/src/lib/status-bar-manager.ts
@@ -25,7 +25,7 @@ export class StatusBarManager {
     this.statusBarItem = vscode.window.createStatusBarItem(
       vscode.StatusBarAlignment.Left
     );
-    this.updateState(StatusBarState.Idle, 'Idle');
+    this.updateState(StatusBarState.Idle, 'Idle - Click to pause');
     this.statusBarItem.show();
 
     context.subscriptions.push(this.statusBarItem);
@@ -63,10 +63,24 @@ export class StatusBarManager {
 
   /**
    * Sets the status bar to the idle state.
-   * This method updates the status bar state to `Idle` and displays 'Idle' as the status text.
+   * This method updates the status bar state to `Idle` and displays 'Idle - Click to pause' as the status text.
    */
   public setIdle() {
-    this.updateState(StatusBarState.Idle, 'Idle');
+    this.updateState(StatusBarState.Idle, 'Idle - Click to pause');
+  }
+
+  /**
+   * Sets a click handler for the status bar item.
+   *
+   * @param commandLabel - A descriptive label for the command, used in the tooltip.
+   * @param commandName - The name of the command to be executed when the status bar item is clicked.
+   * @param handler - A callback function to be executed when the command is triggered.
+   */
+  public setClickHandler(commandName: string) {
+    this.statusBarItem.command = {
+      title: this.extensionName,
+      command: commandName,
+    };
   }
 
   public static disposeInstance() {

--- a/src/libs/feature/feature-status-bar-manager/src/lib/status-bar-manager.types.ts
+++ b/src/libs/feature/feature-status-bar-manager/src/lib/status-bar-manager.types.ts
@@ -2,4 +2,5 @@ export enum StatusBarState {
   Idle = 'eye',
   Running = 'sync~spin',
   FetchingData = 'cloud-download~spin',
+  Paused = 'eye-closed',
 }

--- a/src/libs/module/module-i18next-scanner/src/lib/i18next-scanner-module.test.ts
+++ b/src/libs/module/module-i18next-scanner/src/lib/i18next-scanner-module.test.ts
@@ -23,7 +23,17 @@ suite('I18nextScannerModule', () => {
     getConfigStub.withArgs('i18nextScannerModule').returns({ enabled: true });
     extensionContext = {} as vscode.ExtensionContext;
 
-    extensionContext = {} as vscode.ExtensionContext;
+    extensionContext = {
+      globalState: {
+        get: sinon.stub().callsFake((key: string) => {
+          if (key === 'i18nWeave.isPaused') {
+            return false;
+          }
+          return undefined;
+        }),
+        update: sinon.stub().resolves(),
+      },
+    } as unknown as vscode.ExtensionContext;
     scannerModule = new I18nextScannerModule(extensionContext);
     scannerServiceStub = sinon.createStubInstance(I18nextScannerService);
     scannerServiceScanCodeStub = scannerServiceStub.scanCode = sinon.stub();

--- a/src/libs/module/module-i18next-scanner/src/lib/i18next-scanner-module.ts
+++ b/src/libs/module/module-i18next-scanner/src/lib/i18next-scanner-module.ts
@@ -58,6 +58,8 @@ export class I18nextScannerModule extends BaseActionModule {
             'I18nextScannerModule'
           );
         }, 1000);
+
+        FileStore.getInstance().addOrUpdateFilesAsync(translationFileUris);
       };
 
       if (

--- a/src/libs/module/module-translation/src/lib/translation-module.ts
+++ b/src/libs/module/module-translation/src/lib/translation-module.ts
@@ -17,10 +17,10 @@ import { FileWriter } from '@i18n-weave/file-io/file-io-file-writer';
 import { FileLockStore } from '@i18n-weave/store/store-file-lock-store';
 import { FileStore } from '@i18n-weave/store/store-file-store';
 
-// import { TranslationStore } from '@i18n-weave/store/store-translation-store';
 import {
   ConfigurationStoreManager,
   GeneralConfiguration,
+  TranslationModuleConfiguration,
 } from '@i18n-weave/util/util-configuration';
 import { applyChange, diffJsonObjects } from '@i18n-weave/util/util-file-diff';
 import { extractLocaleFromFileUri } from '@i18n-weave/util/util-file-path-utilities';
@@ -101,7 +101,7 @@ export class TranslationModule extends BaseActionModule {
       await this.applyTranslationsToFiles(
         otherFiles,
         translationsByLanguage,
-        config
+        generalConfig
       );
       // TranslationStore.getInstance().updateEntry(
       //   context.inputPath,

--- a/src/libs/module/module-translation/src/lib/translation-module.ts
+++ b/src/libs/module/module-translation/src/lib/translation-module.ts
@@ -17,10 +17,10 @@ import { FileWriter } from '@i18n-weave/file-io/file-io-file-writer';
 import { FileLockStore } from '@i18n-weave/store/store-file-lock-store';
 import { FileStore } from '@i18n-weave/store/store-file-store';
 
+// import { TranslationStore } from '@i18n-weave/store/store-translation-store';
 import {
   ConfigurationStoreManager,
   GeneralConfiguration,
-  TranslationModuleConfiguration,
 } from '@i18n-weave/util/util-configuration';
 import { applyChange, diffJsonObjects } from '@i18n-weave/util/util-file-diff';
 import { extractLocaleFromFileUri } from '@i18n-weave/util/util-file-path-utilities';
@@ -101,7 +101,7 @@ export class TranslationModule extends BaseActionModule {
       await this.applyTranslationsToFiles(
         otherFiles,
         translationsByLanguage,
-        generalConfig
+        config
       );
       // TranslationStore.getInstance().updateEntry(
       //   context.inputPath,

--- a/src/libs/module/module-translation/src/lib/translation-module.ts
+++ b/src/libs/module/module-translation/src/lib/translation-module.ts
@@ -39,6 +39,14 @@ export class TranslationModule extends BaseActionModule {
       ConfigurationStoreManager.getInstance().getConfig<GeneralConfiguration>(
         'general'
       );
+    if (this.extensionContext.globalState.get('i18nWeave.isPaused')) {
+      this.logger.log(
+        LogLevel.INFO,
+        'Extension is paused. Skipping translation module.',
+        this._className
+      );
+      return;
+    }
     if (!context.jsonContent) {
       return;
     }

--- a/src/libs/store/store-file-store/src/lib/file-store.test.ts
+++ b/src/libs/store/store-file-store/src/lib/file-store.test.ts
@@ -38,7 +38,7 @@ suite('FileLocationStore Tests', function () {
     sandbox.stub(vscode.workspace, 'findFiles').resolves(mockFiles);
     const addOrUpdateFileStub = sandbox.stub<any, any>(
       store,
-      'addOrUpdateFile'
+      'addOrUpdateFileAsync'
     );
 
     const fileSearchLocations = [

--- a/src/libs/store/store-file-store/src/lib/file-store.types.ts
+++ b/src/libs/store/store-file-store/src/lib/file-store.types.ts
@@ -14,15 +14,19 @@ type Metadata = {
 };
 
 type FileData = {
-  content: string;
   metaData: Metadata;
 };
 
 export type TranslationFile = {
+  type: 'translation';
   language: string;
   namespace: string;
   dialect?: string;
   keys: Record<string, TranslationKeyData>;
+  jsonContent: JSON;
 } & FileData;
 
-export type CodeFile = FileData;
+export type CodeFile = {
+  type: 'code';
+  content: string;
+} & FileData;

--- a/src/libs/util/util-configuration/src/lib/configuration-store/configuration-store.test.ts
+++ b/src/libs/util/util-configuration/src/lib/configuration-store/configuration-store.test.ts
@@ -58,6 +58,7 @@ suite('ConfigurationStore Tests', () => {
         },
       },
       translationModule: {
+        enabled: true,
         deepL: {
           apiKey: 'apiKey',
           enabled: true,

--- a/src/libs/util/util-configuration/src/lib/modules/translation-module/translation-module-configuration.ts
+++ b/src/libs/util/util-configuration/src/lib/modules/translation-module/translation-module-configuration.ts
@@ -5,6 +5,7 @@ import { GoogleTranslateConfiguration } from './google-translate-configuration';
  * Represents the Configurationuration for the translation module.
  */
 export class TranslationModuleConfiguration {
+  enabled: boolean = true;
   googleTranslate: GoogleTranslateConfiguration =
     new GoogleTranslateConfiguration();
   deepL: DeepLConfiguration = new DeepLConfiguration();

--- a/src/libs/util/util-util-never/src/index.ts
+++ b/src/libs/util/util-util-never/src/index.ts
@@ -1,0 +1,1 @@
+export * from './lib/util-never';

--- a/src/libs/util/util-util-never/src/lib/util-never.test.ts
+++ b/src/libs/util/util-util-never/src/lib/util-never.test.ts
@@ -1,0 +1,2 @@
+/* eslint-disable no-restricted-imports */
+// Tests for UtilNever

--- a/src/libs/util/util-util-never/src/lib/util-never.ts
+++ b/src/libs/util/util-util-never/src/lib/util-never.ts
@@ -1,0 +1,9 @@
+/**
+ * Throws an error with a descriptive message stating that the code should never be reached.
+ * Use this function to make sure that the code is not reached in any case.
+ * @param message Descriptive message for the error. Stating the reason why the code should never be reached.
+ */
+export function neverReached(message: string): never {
+  throw new Error(message);
+}
+

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,9 @@
   "compilerOptions": {
     "baseUrl": "./",
     "paths": {
-      "@i18n-weave/core/*": ["src/core/*"],
+      "@i18n-weave/core/*": [
+        "src/core/*"
+      ],
       "@i18n-weave/feature/feature-active-text-editor-changed-handler": [
         "src/libs/feature/feature-active-text-editor-changed-handler/src"
       ],
@@ -63,7 +65,9 @@
       "@i18n-weave/file-io/file-io-file-writer": [
         "src/libs/file-io/file-io-file-writer/src"
       ],
-      "@i18n-weave/http/*": ["src/libs/http/http-*/src/"],
+      "@i18n-weave/http/*": [
+        "src/libs/http/http-*/src/"
+      ],
       "@i18n-weave/http/http-deepl-client": [
         "src/libs/http/http-deepl-client/src/"
       ],
@@ -97,11 +101,15 @@
       "@i18n-weave/util/util-configuration": [
         "src/libs/util/util-configuration/src"
       ],
-      "@i18n-weave/util/util-decorators": ["src/libs/util/util-decorators/src"],
+      "@i18n-weave/util/util-decorators": [
+        "src/libs/util/util-decorators/src"
+      ],
       "@i18n-weave/util/util-environment-utilities": [
         "src/libs/util/util-environment-utilities/src"
       ],
-      "@i18n-weave/util/util-enums": ["src/libs/util/util-enums/src"],
+      "@i18n-weave/util/util-enums": [
+        "src/libs/util/util-enums/src"
+      ],
       "@i18n-weave/util/util-file-path-utilities": [
         "src/libs/util/util-file-path-utilities/src/"
       ],
@@ -111,18 +119,24 @@
       "@i18n-weave/util/util-localization-utilities": [
         "src/libs/util/util-localization-utilities/src"
       ],
-      "@i18n-weave/util/util-logger": ["src/libs/util/util-logger/src"],
+      "@i18n-weave/util/util-logger": [
+        "src/libs/util/util-logger/src"
+      ],
       "@i18n-weave/util/util-prompt-utilities": [
         "src/libs/util/util-prompt-utilities/src"
       ],
-      "@i18n-weave/util/util-types": ["src/libs/util/util-types/src"],
+      "@i18n-weave/util/util-types": [
+        "src/libs/util/util-types/src"
+      ],
       "@i18n-weave/feature/feature-file-location-initializer": [
         "src/libs/feature/feature-file-location-initializer/src"
       ],
       "@i18n-weave/store/store-translation-store": [
         "src/libs/store/store-translation-store/src"
       ],
-      "@i18n-weave/util/util-file-diff": ["src/libs/util/util-file-diff/src"],
+      "@i18n-weave/util/util-file-diff": [
+        "src/libs/util/util-file-diff/src"
+      ],
       "@i18n-weave/util/util-nested-object-utils": [
         "src/libs/util/util-nested-object-utils/src"
       ],
@@ -146,12 +160,17 @@
       ],
       "@i18n-weave/util/util-i18next-file-utils": [
         "src/libs/util/util-i18next-file-utils/src"
+      ],
+      "@i18n-weave/util/util-util-never": [
+        "src/libs/util/util-util-never/src"
       ]
     },
     "module": "CommonJS",
     "target": "ES2022",
     "outDir": "out",
-    "lib": ["ES2022"],
+    "lib": [
+      "ES2022"
+    ],
     "sourceMap": true,
     "rootDir": "src",
     "strict": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,9 +2,7 @@
   "compilerOptions": {
     "baseUrl": "./",
     "paths": {
-      "@i18n-weave/core/*": [
-        "src/core/*"
-      ],
+      "@i18n-weave/core/*": ["src/core/*"],
       "@i18n-weave/feature/feature-active-text-editor-changed-handler": [
         "src/libs/feature/feature-active-text-editor-changed-handler/src"
       ],
@@ -65,9 +63,7 @@
       "@i18n-weave/file-io/file-io-file-writer": [
         "src/libs/file-io/file-io-file-writer/src"
       ],
-      "@i18n-weave/http/*": [
-        "src/libs/http/http-*/src/"
-      ],
+      "@i18n-weave/http/*": ["src/libs/http/http-*/src/"],
       "@i18n-weave/http/http-deepl-client": [
         "src/libs/http/http-deepl-client/src/"
       ],
@@ -101,15 +97,11 @@
       "@i18n-weave/util/util-configuration": [
         "src/libs/util/util-configuration/src"
       ],
-      "@i18n-weave/util/util-decorators": [
-        "src/libs/util/util-decorators/src"
-      ],
+      "@i18n-weave/util/util-decorators": ["src/libs/util/util-decorators/src"],
       "@i18n-weave/util/util-environment-utilities": [
         "src/libs/util/util-environment-utilities/src"
       ],
-      "@i18n-weave/util/util-enums": [
-        "src/libs/util/util-enums/src"
-      ],
+      "@i18n-weave/util/util-enums": ["src/libs/util/util-enums/src"],
       "@i18n-weave/util/util-file-path-utilities": [
         "src/libs/util/util-file-path-utilities/src/"
       ],
@@ -119,24 +111,18 @@
       "@i18n-weave/util/util-localization-utilities": [
         "src/libs/util/util-localization-utilities/src"
       ],
-      "@i18n-weave/util/util-logger": [
-        "src/libs/util/util-logger/src"
-      ],
+      "@i18n-weave/util/util-logger": ["src/libs/util/util-logger/src"],
       "@i18n-weave/util/util-prompt-utilities": [
         "src/libs/util/util-prompt-utilities/src"
       ],
-      "@i18n-weave/util/util-types": [
-        "src/libs/util/util-types/src"
-      ],
+      "@i18n-weave/util/util-types": ["src/libs/util/util-types/src"],
       "@i18n-weave/feature/feature-file-location-initializer": [
         "src/libs/feature/feature-file-location-initializer/src"
       ],
       "@i18n-weave/store/store-translation-store": [
         "src/libs/store/store-translation-store/src"
       ],
-      "@i18n-weave/util/util-file-diff": [
-        "src/libs/util/util-file-diff/src"
-      ],
+      "@i18n-weave/util/util-file-diff": ["src/libs/util/util-file-diff/src"],
       "@i18n-weave/util/util-nested-object-utils": [
         "src/libs/util/util-nested-object-utils/src"
       ],
@@ -161,16 +147,12 @@
       "@i18n-weave/util/util-i18next-file-utils": [
         "src/libs/util/util-i18next-file-utils/src"
       ],
-      "@i18n-weave/util/util-util-never": [
-        "src/libs/util/util-util-never/src"
-      ]
+      "@i18n-weave/util/util-util-never": ["src/libs/util/util-util-never/src"]
     },
     "module": "CommonJS",
     "target": "ES2022",
     "outDir": "out",
-    "lib": [
-      "ES2022"
-    ],
+    "lib": ["ES2022"],
     "sourceMap": true,
     "rootDir": "src",
     "strict": true,
@@ -180,7 +162,7 @@
     "experimentalDecorators": true,
     "resolveJsonModule": true,
     "inlineSources": true,
-    "noUnusedLocals": true,
-    "noUnusedParameters": true
+    "noUnusedLocals": false,
+    "noUnusedParameters": false
   }
 }


### PR DESCRIPTION
### Description

This pull request addresses an issue in the translation update mechanism where changes to translation keys, especially newly added ones, would not consistently propagate updates to related keys across different i18n translation files. This inconsistency often meant that the initial change was missed, leading to translation discrepancies.

### Changes

- Enhanced the translation trigger mechanism to ensure that any modification to translation keys, including the very first change to new keys, is correctly detected and consistently propagated to all associated i18n translation files.

### Impact

- Developers will benefit from a smoother translation update process, as they no longer need to manually verify whether changes have been detected after the first modification.